### PR TITLE
docs: fix Gemfile dependencies and add logo to index

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,5 +2,4 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.0"
 gem "jekyll-theme-slate"
-gem "github-pages", "~> 231"
 gem "webrick", "~> 1.8"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,11 @@
-# Documentation Index
+# Matimo Documentation
+<p align="center">
+<img src="./assets/logo.png" alt="Matimo Logo" width="120" style="border-radius: 8px; margin: 20px 0;" />
+</p>
+
+**Matimo** (Maximum AI Tools in Modular Objects) — Define tools once in YAML, use them everywhere.
+
+> Built to solve the universal tool orchestration problem for AI agents.
 
 Complete documentation for Matimo.
 
@@ -277,16 +284,5 @@ See [Contributing Guidelines](../CONTRIBUTING.md).
 - **Want to contribute?** See [Contributing Guidelines](../CONTRIBUTING.md)
 
 ---
-
-## Documentation Quality
-
-All documentation in Matimo follows these standards:
-
-- ✅ Clear and concise with practical examples
-- ✅ Links between related sections
-- ✅ Code examples that actually work
-- ✅ Type-safe TypeScript (strict mode)
-- ✅ Aligned with actual project practices
-- ✅ Updated whenever code changes
 
 Last updated: February 2026


### PR DESCRIPTION
## Description
This pull request updates the documentation for Matimo, focusing on improving clarity, branding, and simplifying the setup. The most important changes include a redesigned documentation index page and a streamlined Gemfile for building the docs.

Documentation improvements:

* Updated `docs/index.md` with a new title, project logo, and a concise description of Matimo to better communicate the project's purpose and branding.
* Removed the "Documentation Quality" section from `docs/index.md` to simplify the index and focus on essential information.

Build configuration simplification:

* Removed the `github-pages` gem from `docs/Gemfile`, reducing unnecessary dependencies for building documentation locally.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Tool addition
- [ ] Tool modification

## Testing
- [ ] Tests added
- [ ] All tests passing
- [ ] Coverage maintained (>90%)

## Checklist
- [ ] Code formatted (`pnpm format`)
- [ ] Linting passes (`pnpm lint`)
- [ ] Tests passing (`pnpm test`)
- [ ] Documentation updated
- [ ] No console.log statements
- [ ] No hardcoded secrets
- [ ] Tool YAML validated (if applicable)

## Related Issues
Closes #[issue number]
