### PR TITLE
chore: rollback to slate theme for github pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
-remote_theme: alshedivat/al-folio
+theme: jekyll-theme-slate
 title: Matimo - AI Tools Ecosystem
 description: Define tools once in YAML, use them everywhere
+show_downloads: true
 google_analytics: false
 
 # Matimo Documentation


### PR DESCRIPTION
## Description

This pull request makes a small change to the documentation site configuration by switching the Jekyll theme to `jekyll-theme-slate` and enabling download links.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Tool addition
- [ ] Tool modification

## Testing
- [ ] Tests added
- [ ] All tests passing
- [ ] Coverage maintained (>90%)

## Checklist
- [ ] Code formatted (`pnpm format`)
- [ ] Linting passes (`pnpm lint`)
- [ ] Tests passing (`pnpm test`)
- [ ] Documentation updated
- [ ] No console.log statements
- [ ] No hardcoded secrets
- [ ] Tool YAML validated (if applicable)

## Related Issues
Closes #[issue number]
