### PR TITLE
Patch/v0.1.0 alpha.12.1

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,3 +1,74 @@
+## v0.1.0-alpha.12.1
+
+> Release: Per-Execution Credential Override — Multi-tenant credential injection, `getRequiredCredentials()` DX helper, package-level release workflow (Changesets), improved test coverage
+
+**Released**: March 12, 2026
+
+### 🚀 Features
+
+**Per-Execution Credential Override** (`@matimo/core`)
+
+- **`ExecuteOptions.credentials`** — Pass `Record<string, string>` per `execute()` call; credentials are scoped to that execution and never written to `process.env`
+- **Priority lookup chain**: `credentials[key]` → `credentials[MATIMO_key]` → `process.env[MATIMO_key]` → `process.env[key]`
+- **All executor types updated**: `HttpExecutor`, `CommandExecutor`, `FunctionExecutor` all accept and forward per-call credentials
+- **Fully backward compatible**: existing code without `options` is unaffected
+
+**`getRequiredCredentials(toolName)` DX Helper** (`@matimo/core`)
+
+- Returns the exact credential key names a tool expects (`string[]`)
+- Scans `{PLACEHOLDER}` patterns in headers, URL, body, and `query_params` for auth-pattern names
+- Also includes `username_env` / `password_env` from `authentication.type: basic` config
+- Throws `MatimoError(TOOL_NOT_FOUND)` for unknown tool names
+- Enables multi-tenant credential manifest pattern:
+  ```typescript
+  const keys = matimo.getRequiredCredentials('slack-send-message');
+  // → ['SLACK_BOT_TOKEN']
+  const credentials = Object.fromEntries(keys.map(k => [k, tenant.secrets[k]]));
+  await matimo.execute('slack-send-message', params, { credentials });
+  ```
+
+**New Example: Multi-Tenant Credentials** (`examples/tools/credentials/`)
+
+- Runnable demo showing per-tenant credential isolation with `Promise.all` parallel execution
+- Verifies `process.env` immutability and env-var fallback behaviour
+- Credential key reference table for all Slack tools
+- Script: `pnpm credentials:example`
+
+**Package-Level Release Workflow**
+
+- Replaced monolithic tag-based `npm-release.yml` with [Changesets](https://github.com/changesets/changesets) action
+- Triggers on `push` to `main`; opens a "Version Packages" PR for pending changesets
+- On merge of the version PR, publishes only changed packages with per-package GitHub release tags
+- `.changeset/config.json` initialised with `access: public`
+
+### 🧪 Test Coverage
+
+- **26 new tests** in `credentials-override.test.ts` covering all executors, credential priority, `getRequiredCredentials()`, and `process.env` immutability
+- **8 new branch-coverage tests** in `matimo-instance.test.ts` targeting previously uncovered paths:
+  - `params.command` scan for command-type tools
+  - `params.sql` destructive-keyword scan
+  - `MATIMO_APPROVAL_SCAN_ALL_PARAMS=true` path
+  - Approval callback invocation
+  - Basic-auth `username_env`/`password_env` in `getRequiredCredentials()`
+  - `scanObjectForParams` non-object early return & circular reference guard
+  - `getExecutor` unsupported-type throw
+- `matimo-instance.ts` statements and lines: **100%** (up from 88.81% / 89.74%)
+- Full suite: **1298+ tests passing**
+
+### 📦 Packages
+
+All packages bumped to v0.1.0-alpha.12.1:
+
+- `@matimo/core` — `ExecuteOptions`, `getRequiredCredentials()`, new tests
+- `@matimo/cli` — Version sync
+- `@matimo/slack`, `@matimo/github`, `@matimo/gmail`, `@matimo/hubspot`, `@matimo/mailchimp`, `@matimo/notion`, `@matimo/postgres`, `@matimo/twilio` — Version sync
+
+### ⚠️ Breaking Changes
+
+None. The `options` parameter on `execute()` is optional; all existing call sites continue to work unchanged.
+
+---
+
 ## v0.1.0-alpha.12
 
 > Release: First-Class MCP Support — Standalone server, pluggable secrets, Claude Desktop integration, comprehensive examples

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -34,12 +34,6 @@
 - Credential key reference table for all Slack tools
 - Script: `pnpm credentials:example`
 
-**Package-Level Release Workflow**
-
-- Replaced monolithic tag-based `npm-release.yml` with [Changesets](https://github.com/changesets/changesets) action
-- Triggers on `push` to `main`; opens a "Version Packages" PR for pending changesets
-- On merge of the version PR, publishes only changed packages with per-package GitHub release tags
-- `.changeset/config.json` initialised with `access: public`
 
 ### 🧪 Test Coverage
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-**Latest Release**: v0.1.0-alpha.12 (March 11, 2026)
+**Latest Release**: v0.1.0-alpha.12.1 (March 12, 2026)
 
 ✅ **Completed Features**:
 
@@ -13,10 +13,14 @@
 - Core tools suite (execute, read, edit, search, web, calculator)
 - Provider integrations (Slack with 16+ tools, Gmail with 5 tools, GitHub, HubSpot with 50+ tools, Notion with 7 tools)
 - CLI tool management (list, search, install, help)
-- 800+ comprehensive test suite with 85%+ coverage
+- 1298+ comprehensive test suite with 100% line/statement coverage on core
 - Complete documentation and examples
 - Structured error handling with MatimoError and error chaining
 - Enhanced HTTP executor with parameter embedding (objects, arrays)
+- MCP Server (dual-transport stdio + HTTP, pluggable secrets, Claude Desktop integration)
+- **Per-execution credential override** — multi-tenant `options.credentials` on `execute()`
+- **`getRequiredCredentials()`** — DX helper to discover required credential keys per tool
+- Package-level release workflow via Changesets
 
 **See [RELEASES.md](./RELEASES.md)** for detailed release notes on completed features.
 
@@ -190,7 +194,8 @@ Alpha Phase (✅ Completed)
   v0.1.0-alpha.9  Feb 19, 2026  (HubSpot tools)
   v0.1.0-alpha.10 Feb 21, 2026  (Notion tools)
   v0.1.0-alpha.11 Feb 27, 2026  (Twilio & Mailchimp tools)
-  v0.1.0-alpha.12 Mar 11, 2026  (🚀 MCP Server — stdio + HTTP, secrets, Claude integration) ← Current
+  v0.1.0-alpha.12   Mar 11, 2026  (🚀 MCP Server — stdio + HTTP, secrets, Claude integration)
+  v0.1.0-alpha.12.1 Mar 12, 2026  (🔑 Per-execution credential override, getRequiredCredentials(), Changesets release workflow) ← Current
 
 v0.1.0 Release (📅 Late March 2026)
   ✅ Completed:
@@ -204,6 +209,7 @@ v0.1.0 Release (📅 Late March 2026)
     2. Python SDK               March-April 2026
     3. Logging & Monitoring     April 2026
     4. Skills/Workflows         April-May 2026
+    5. Changeset-driven package releases (in progress)
 
   v0.1.0-rc.1     Late March 2026
   v0.1.0          March 2026 ← Stable Release

--- a/docs/api-reference/SDK.md
+++ b/docs/api-reference/SDK.md
@@ -7,6 +7,7 @@ Complete reference for the Matimo TypeScript SDK. For a simpler introduction, se
 - [MatimoInstance](#matimoinstance)
   - [init()](#initoptions)
   - [execute()](#executetoolname-params)
+  - [getRequiredCredentials()](#getrequiredcredentialstoolname)
   - [listTools()](#listtools)
   - [getTool()](#gettoolname)
   - [searchTools()](#searchtoolsquery)
@@ -80,8 +81,20 @@ Execute a tool by name with parameters.
 async execute(
   toolName: string,
   params: Record<string, unknown>,
-  options?: { timeout?: number }
+  options?: ExecuteOptions
 ): Promise<unknown>
+
+interface ExecuteOptions {
+  /** Execution timeout in milliseconds. */
+  timeout?: number;
+  /**
+   * Per-call credential overrides for multi-tenant use.
+   * Keys must match the env-var names the tool references (e.g. `SLACK_BOT_TOKEN`).
+   * When provided, they take precedence over `process.env` for that single call.
+   * Values are never logged and are held in memory only for the duration of the call.
+   */
+  credentials?: Record<string, string>;
+}
 ```
 
 **Parameters:**
@@ -89,6 +102,7 @@ async execute(
 - `toolName` (string, required) - Exact name of the tool to execute
 - `params` (object, required) - Tool parameters (must match tool's parameter schema)
 - `options.timeout` (number, optional) - Execution timeout in milliseconds
+- `options.credentials` (object, optional) - Per-call credential overrides (see Multi-tenant Usage below)
 
 **Returns:** `Promise<unknown>` - Tool result (validated against output schema)
 
@@ -100,7 +114,7 @@ async execute(
 - `MatimoError(AUTH_FAILED)` - If authentication fails
 - `MatimoError(TIMEOUT)` - If execution exceeds timeout
 
-**Example:**
+**Example (single-tenant):**
 
 ```typescript
 import { MatimoInstance, MatimoError } from 'matimo';
@@ -108,7 +122,7 @@ import { MatimoInstance, MatimoError } from 'matimo';
 const matimo = await MatimoInstance.init({ autoDiscover: true });
 
 try {
-  // Execute calculator tool
+  // Credentials read from process.env (SLACK_BOT_TOKEN, etc.)
   const result = await matimo.execute('calculator', {
     operation: 'add',
     a: 10,
@@ -116,7 +130,6 @@ try {
   });
   console.log('Result:', result); // { result: 15 }
 
-  // Execute another tool
   const slackResult = await matimo.execute('slack-send-message', {
     channel: '#general',
     text: 'Hello',
@@ -126,6 +139,128 @@ try {
   if (error instanceof MatimoError) {
     console.error(`Error [${error.code}]:`, error.message);
   }
+}
+```
+
+**Multi-tenant Usage:**
+
+Different tenants can supply their own credentials **per call** without touching
+`process.env`. This lets a single process serve many tenants safely.
+
+```typescript
+import { MatimoInstance } from 'matimo';
+
+const matimo = await MatimoInstance.init({ autoDiscover: true });
+
+// Tenant A — uses their own Slack token
+await matimo.execute(
+  'slack-send-message',
+  { channel: '#general', text: 'Hello from Tenant A' },
+  { credentials: { SLACK_BOT_TOKEN: 'xoxb-tenant-a-token' } }
+);
+
+// Tenant B — same process, completely isolated credentials
+await matimo.execute(
+  'slack-send-message',
+  { channel: '#general', text: 'Hello from Tenant B' },
+  { credentials: { SLACK_BOT_TOKEN: 'xoxb-tenant-b-token' } }
+);
+
+// Timeout + credentials together
+await matimo.execute(
+  'github-create-issue',
+  { repo: 'myorg/myrepo', title: 'Bug report' },
+  {
+    timeout: 10_000,
+    credentials: { GITHUB_ACCESS_TOKEN: 'ghp-tenant-c-token' },
+  }
+);
+```
+
+**Credential key naming convention:**
+
+Credential keys must match the env-var names the tool's YAML definition
+references (e.g. `SLACK_BOT_TOKEN`, `GITHUB_ACCESS_TOKEN`). The credential
+value is resolved in this order for each placeholder found in the tool YAML:
+
+1. `credentials[paramName]` — per-call override (highest priority)
+2. `credentials[MATIMO_${paramName}]` — prefixed per-call override
+3. `process.env[MATIMO_${paramName}]` — prefixed env var
+4. `process.env[paramName]` — direct env var (lowest priority)
+
+**Security notes:**
+- Credential values are **never logged** by the Matimo SDK.
+- Credentials are **never persisted** — held in memory only for the life of the call.
+- `process.env` is **never modified** — each call's credentials are isolated.
+- For `command` tools, credentials are merged into the child-process environment
+  (`{ ...process.env, ...credentials }`) and not leaked back to the parent process.
+
+---
+
+### `getRequiredCredentials(toolName)`
+
+Return the credential key names a tool needs, so callers know exactly what to
+put in `options.credentials` without reading the tool YAML.
+
+This is the primary discovery API for multi-tenant platforms: call this once
+when building your tenant-credential collection step, then pass the result
+directly to `execute()`.
+
+**Signature:**
+
+```typescript
+getRequiredCredentials(toolName: string): string[]
+```
+
+**Parameters:**
+
+- `toolName` (string, required) — Exact tool name
+
+**Returns:** `string[]` — Array of credential key names the tool requires (empty if the tool needs no auth)
+
+**Throws:** `MatimoError(TOOL_NOT_FOUND)` if the tool doesn't exist
+
+**Example:**
+
+```typescript
+const matimo = await MatimoInstance.init({ autoDiscover: true });
+
+// 1. Discover what credentials this tool needs
+const keys = matimo.getRequiredCredentials('slack-send-message');
+console.log(keys); // → ['SLACK_BOT_TOKEN']
+
+// 2. Collect those values from your secrets store / tenant config
+const credentials = Object.fromEntries(
+  keys.map((key) => [key, tenant.vault.get(key)])
+);
+
+// 3. Execute with isolated per-tenant credentials
+await matimo.execute('slack-send-message', params, { credentials });
+```
+
+**Multi-tool credential prep:**
+
+```typescript
+// Build a credential map for every installed tool at startup
+const credentialManifest = Object.fromEntries(
+  matimo.listTools().map((tool) => [
+    tool.name,
+    matimo.getRequiredCredentials(tool.name),
+  ])
+);
+
+// credentialManifest looks like:
+// {
+//   'slack-send-message':   ['SLACK_BOT_TOKEN'],
+//   'github-create-issue':  ['GITHUB_ACCESS_TOKEN'],
+//   'twilio-send-sms':      ['TWILIO_ACCOUNT_SID', 'TWILIO_AUTH_TOKEN'],
+// }
+
+// When a request comes in for tenant X, collect only what that tool needs:
+async function runForTenant(toolName: string, params: Record<string, unknown>, tenant: Tenant) {
+  const keys = credentialManifest[toolName];
+  const credentials = Object.fromEntries(keys.map((k) => [k, tenant.secrets[k]]));
+  return matimo.execute(toolName, params, { credentials });
 }
 ```
 

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matimo-mcp-examples",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Matimo MCP examples - LangChain agents via stdio and Streamable HTTP",
   "type": "module",
   "scripts": {

--- a/examples/tools/credentials/credentials-example.ts
+++ b/examples/tools/credentials/credentials-example.ts
@@ -122,7 +122,9 @@ async function main() {
     }
 
     if (missing.length > 0) {
-      console.warn(`   ⚠️  [${tenant.name}] Missing keys for '${toolName}': ${missing.join(', ')}`);
+      console.warn(
+        `   ⚠️  [${tenant.name}] Missing ${missing.length} credential key(s) for '${toolName}'.`
+      );
     }
 
     console.info(
@@ -203,7 +205,9 @@ async function main() {
   for (const tool of slackTools.slice(0, 5)) {
     const keys = matimo.getRequiredCredentials(tool.name);
     console.info(`   ${tool.name}`);
-    console.info(`     credentials keys: ${keys.length ? keys.join(', ') : '(none required)'}`);
+    console.info(
+      `     credentials required: ${keys.length ? `${keys.length} key(s)` : '(none required)'}`
+    );
   }
   if (slackTools.length > 5) {
     console.info(`   … and ${slackTools.length - 5} more Slack tools`);

--- a/examples/tools/credentials/credentials-example.ts
+++ b/examples/tools/credentials/credentials-example.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * ============================================================================
+ * PER-EXECUTION CREDENTIAL OVERRIDE — MULTI-TENANT EXAMPLE
+ * ============================================================================
+ *
+ * PATTERN: Per-call credentials (options.credentials)
+ * ─────────────────────────────────────────────────────────────────────────
+ * Demonstrates how to supply credentials per `execute()` call instead of
+ * relying on environment variables. This is the right pattern for
+ * multi-tenant platforms where each user/tenant has their own API keys.
+ *
+ * Use this pattern when:
+ * ✅ Serving multiple tenants from a single process
+ * ✅ Credentials come from a database / secrets manager / vault
+ * ✅ You must NOT store per-tenant tokens in process.env
+ * ✅ You want strict per-call credential isolation
+ *
+ * Contrast with single-tenant pattern (env vars):
+ *   SLACK_BOT_TOKEN=xoxb-xxx matimo execute slack-send-message ...
+ *   → works fine for one account, breaks for ten tenants
+ *
+ * SETUP:
+ * ─────────────────────────────────────────────────────────────────────────
+ * No .env token needed — this example uses placeholder tenant tokens to
+ * show the API shape. Real requests will fail (expected). To see real calls
+ * succeed, replace the placeholder tokens with real Slack bot tokens.
+ *
+ * USAGE:
+ * ─────────────────────────────────────────────────────────────────────────
+ *   pnpm credentials:example
+ *
+ * KEY CONCEPTS DEMONSTRATED:
+ * ─────────────────────────────────────────────────────────────────────────
+ * 1. getRequiredCredentials(toolName) — discover what keys a tool needs
+ * 2. execute(name, params, { credentials }) — per-call credential injection
+ * 3. Tenant isolation — two tenants, same process, different tokens
+ * 4. Graceful partial credentials — credential + env-var fallback strategy
+ * 5. Credential manifest — build a map of all tools → required keys at startup
+ *
+ * ============================================================================
+ */
+
+import 'dotenv/config';
+import { MatimoInstance } from 'matimo';
+
+// ─── Simulated tenant "database" ─────────────────────────────────────────────
+// In a real platform these would come from your DB / vault / secrets manager.
+const TENANTS = {
+  'tenant-acme': {
+    name: 'Acme Corp',
+    secrets: {
+      // Replace with a real token to see live Slack calls
+      SLACK_BOT_TOKEN: process.env.ACME_SLACK_BOT_TOKEN ?? 'xoxb-acme-placeholder-token',
+    },
+  },
+  'tenant-globex': {
+    name: 'Globex Inc',
+    secrets: {
+      SLACK_BOT_TOKEN: process.env.GLOBEX_SLACK_BOT_TOKEN ?? 'xoxb-globex-placeholder-token',
+    },
+  },
+};
+
+type TenantId = keyof typeof TENANTS;
+type Tenant = (typeof TENANTS)[TenantId];
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.info('\n╔════════════════════════════════════════════════════════╗');
+  console.info('║   Per-Execution Credential Override — Multi-Tenant     ║');
+  console.info('╚════════════════════════════════════════════════════════╝\n');
+
+  // ── 1. Initialize once — no per-tenant init needed ──────────────────────
+  console.info('🚀 Initializing Matimo (once for all tenants)…');
+  const matimo = await MatimoInstance.init({ autoDiscover: true });
+  console.info(`✅ Loaded ${matimo.listTools().length} tools\n`);
+
+  // ── 2. Discover required credential keys at startup ──────────────────────
+  // getRequiredCredentials() tells you EXACTLY what keys to put in `credentials`
+  // for a given tool — no need to read the YAML.
+  console.info('🔑 Building credential manifest for all tools…');
+  const credentialManifest: Record<string, string[]> = {};
+  for (const tool of matimo.listTools()) {
+    const keys = matimo.getRequiredCredentials(tool.name);
+    if (keys.length > 0) {
+      credentialManifest[tool.name] = keys;
+    }
+  }
+
+  const toolsWithAuth = Object.keys(credentialManifest).length;
+  const toolsNoAuth = matimo.listTools().length - toolsWithAuth;
+  console.info(`   ${toolsWithAuth} tools need credentials, ${toolsNoAuth} are public`);
+  console.info('   Sample manifest entries:');
+  for (const [tool, keys] of Object.entries(credentialManifest).slice(0, 5)) {
+    console.info(`     ${tool}: [${keys.join(', ')}]`);
+  }
+  console.info();
+
+  // ── 3. Per-tenant execution helper ───────────────────────────────────────
+  // Collect only the keys the tool needs from the tenant's secrets store.
+  async function executeForTenant(
+    tenantId: TenantId,
+    toolName: string,
+    params: Record<string, unknown>
+  ) {
+    const tenant: Tenant = TENANTS[tenantId];
+    const requiredKeys = matimo.getRequiredCredentials(toolName);
+
+    // Build credentials map — only the keys this specific tool needs
+    const credentials: Record<string, string> = {};
+    const missing: string[] = [];
+
+    for (const key of requiredKeys) {
+      const value = tenant.secrets[key as keyof typeof tenant.secrets];
+      if (value) {
+        credentials[key] = value;
+      } else {
+        missing.push(key);
+      }
+    }
+
+    if (missing.length > 0) {
+      console.warn(`   ⚠️  [${tenant.name}] Missing keys for '${toolName}': ${missing.join(', ')}`);
+    }
+
+    console.info(
+      `   🏢 [${tenant.name}] Executing '${toolName}' with ${Object.keys(credentials).length} credential(s)…`
+    );
+
+    try {
+      const result = await matimo.execute(toolName, params, { credentials });
+      return { tenantId, toolName, success: true, result };
+    } catch (err) {
+      // Expected for placeholder tokens — real tokens would succeed
+      const message = err instanceof Error ? err.message : String(err);
+      return { tenantId, toolName, success: false, error: message };
+    }
+  }
+
+  // ── 4. Demo: same tool, two tenants, fully isolated ──────────────────────
+  console.info('════════════════════════════════════════════════════════════');
+  console.info('Demo 1: Same tool, two tenants, isolated credentials');
+  console.info('════════════════════════════════════════════════════════════\n');
+
+  const channel = process.env.SLACK_CHANNEL_ID ?? 'C0000000000';
+  const params = { channel, text: `Hello from multi-tenant demo at ${new Date().toISOString()}` };
+
+  const [acmeResult, globexResult] = await Promise.all([
+    executeForTenant('tenant-acme', 'slack-send-message', params),
+    executeForTenant('tenant-globex', 'slack-send-message', params),
+  ]);
+
+  for (const r of [acmeResult, globexResult]) {
+    const icon = r.success ? '✅' : '⚠️ ';
+    const tenant = TENANTS[r.tenantId as TenantId].name;
+    console.info(
+      `   ${icon} [${tenant}] ${r.success ? 'Succeeded' : `Failed (expected with placeholder token): ${r.error?.slice(0, 80)}`}`
+    );
+  }
+
+  // ── 5. Verify process.env was NOT modified ────────────────────────────────
+  console.info('\n════════════════════════════════════════════════════════════');
+  console.info('Demo 2: process.env isolation check');
+  console.info('════════════════════════════════════════════════════════════\n');
+
+  const envBefore = process.env.SLACK_BOT_TOKEN;
+  await executeForTenant('tenant-acme', 'slack-send-message', params);
+  const envAfter = process.env.SLACK_BOT_TOKEN;
+
+  if (envBefore === envAfter) {
+    console.info('   ✅ process.env.SLACK_BOT_TOKEN unchanged — credentials are call-scoped');
+  } else {
+    console.error('   ❌ UNEXPECTED: process.env was mutated!');
+  }
+
+  // ── 6. Fallback to env vars when credentials not provided ─────────────────
+  console.info('\n════════════════════════════════════════════════════════════');
+  console.info('Demo 3: Backward compatibility — no credentials → env var fallback');
+  console.info('════════════════════════════════════════════════════════════\n');
+
+  // Temporarily set env var to simulate single-tenant / legacy usage
+  const wasSet = !!process.env.SLACK_BOT_TOKEN;
+  process.env.SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN ?? 'xoxb-env-fallback-token';
+
+  console.info('   Calling execute() without credentials — falls back to process.env…');
+  try {
+    await matimo.execute('slack-send-message', params);
+    console.info('   ✅ Succeeded (env var token was valid)');
+  } catch {
+    console.info('   ⚠️  Failed at API level (env token is a placeholder — expected)');
+  }
+
+  if (!wasSet) delete process.env.SLACK_BOT_TOKEN;
+
+  // ── 7. Credential key lookup reference ───────────────────────────────────
+  console.info('\n════════════════════════════════════════════════════════════');
+  console.info('Reference: credential keys for Slack tools');
+  console.info('════════════════════════════════════════════════════════════\n');
+
+  const slackTools = matimo.listTools().filter((t) => t.name.startsWith('slack'));
+  for (const tool of slackTools.slice(0, 5)) {
+    const keys = matimo.getRequiredCredentials(tool.name);
+    console.info(`   ${tool.name}`);
+    console.info(`     credentials keys: ${keys.length ? keys.join(', ') : '(none required)'}`);
+  }
+  if (slackTools.length > 5) {
+    console.info(`   … and ${slackTools.length - 5} more Slack tools`);
+  }
+
+  console.info('\n✅ Example complete.\n');
+  console.info('To use real credentials, set per-tenant env vars:');
+  console.info('  ACME_SLACK_BOT_TOKEN=xoxb-acme-real-token');
+  console.info('  GLOBEX_SLACK_BOT_TOKEN=xoxb-globex-real-token\n');
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/examples/tools/package.json
+++ b/examples/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matimo-examples",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Matimo SDK examples - Factory Pattern, Decorator Pattern, and LangChain integration with Slack and Gmail",
   "type": "module",
   "scripts": {

--- a/examples/tools/package.json
+++ b/examples/tools/package.json
@@ -48,6 +48,7 @@
     "twilio:factory": "tsx twilio/twilio-factory.ts",
     "twilio:decorator": "tsx twilio/twilio-decorator.ts",
     "twilio:langchain": "tsx twilio/twilio-langchain.ts",
+    "credentials:example": "tsx credentials/credentials-example.ts",
     "build": "tsc",
     "clean": "rm -rf dist"
   },
@@ -56,6 +57,7 @@
     "@langchain/openai": "^1.2.4",
     "langchain": "^1.2.16",
     "matimo": "workspace:*",
+    "@matimo/core": "workspace:*",
     "@matimo/slack": "workspace:*",
     "@matimo/gmail": "workspace:*",
     "@matimo/postgres": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matimo",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Universal tool provider SDK: Framework-agnostic YAML-driven tool ecosystem for AI agents. Execute a library of pre-built tools (Slack, Gmail, GitHub, AWS, etc.) or define your own in YAML.",
   "main": "packages/core/dist/index.js",
   "types": "packages/core/dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/cli",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "CLI tools for managing Matimo tool installations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/core",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Core SDK for Matimo: Framework-agnostic YAML-driven tool ecosystem for AI agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -185,3 +185,41 @@ export interface ValidationResult {
   valid: boolean;
   errors: ValidationError[];
 }
+
+/**
+ * Options for MatimoInstance.execute()
+ *
+ * @example
+ * // Single-tenant (reads from process.env)
+ * await matimo.execute('slack-send-message', { channel: '#general', text: 'Hello' });
+ *
+ * // Multi-tenant (credentials supplied per call — never touches process.env)
+ * await matimo.execute('slack-send-message', { channel: '#general', text: 'Hello' }, {
+ *   credentials: { SLACK_BOT_TOKEN: 'xoxb-tenant-a-token' },
+ * });
+ */
+export interface ExecuteOptions {
+  /**
+   * Maximum time (ms) to wait for the tool to complete.
+   * Overrides the timeout defined in the tool's YAML definition.
+   */
+  timeout?: number;
+  /**
+   * Per-call credential overrides. Keys must match the env-var names that the
+   * tool's YAML references (e.g. `SLACK_BOT_TOKEN`, `GITHUB_ACCESS_TOKEN`).
+   *
+   * When provided:
+   * - **HttpExecutor**: used for Authorization headers / query params / Basic Auth
+   *   instead of `process.env`.
+   * - **CommandExecutor**: injected as environment variables into the child process
+   *   (`{ ...process.env, ...credentials }`), so spawned scripts see them normally.
+   * - **FunctionExecutor**: passed as `context.credentials` to the tool function.
+   *
+   * When NOT provided the current behaviour is unchanged — credentials are read
+   * from `process.env` as before (fully backward-compatible).
+   *
+   * SECURITY: values are never logged, never persisted, and held only for the
+   * duration of the execute() call.
+   */
+  credentials?: Record<string, string>;
+}

--- a/packages/core/src/encodings/parameter-encoding.ts
+++ b/packages/core/src/encodings/parameter-encoding.ts
@@ -113,8 +113,11 @@ function encodeMimeRfc2822(sourceValues: Record<string, unknown>): string {
 
   // Convert to base64url
   const base64 = Buffer.from(message).toString('base64');
-  // Replace standard base64 characters with URL-safe variants
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  // Replace standard base64 characters with URL-safe variants, then strip
+  // trailing padding. Use while+endsWith instead of a regex to avoid ReDoS.
+  let result = base64.replace(/\+/g, '-').replace(/\//g, '_');
+  while (result.endsWith('=')) result = result.slice(0, -1);
+  return result;
 }
 
 /**

--- a/packages/core/src/executors/command-executor.ts
+++ b/packages/core/src/executors/command-executor.ts
@@ -15,9 +15,20 @@ export class CommandExecutor {
   }
 
   /**
-   * Execute a tool that runs a shell command
+   * Execute a tool that runs a shell command.
+   *
+   * @param tool - Tool definition
+   * @param params - Tool parameters
+   * @param credentials - Optional per-call credential overrides. Keys must match the env-var
+   *   names used by the tool (e.g. `SLACK_BOT_TOKEN`). When provided they are merged on top of
+   *   `process.env` inside the child process so the spawned script sees them as normal env vars.
+   *   Values are never logged. Falls back to the current environment when not provided.
    */
-  async execute(tool: ToolDefinition, params: Record<string, unknown>): Promise<unknown> {
+  async execute(
+    tool: ToolDefinition,
+    params: Record<string, unknown>,
+    credentials?: Record<string, string>
+  ): Promise<unknown> {
     if (tool.execution.type !== 'command') {
       throw new MatimoError('Tool execution type is not command', ErrorCode.EXECUTION_FAILED, {
         expectedType: 'command',
@@ -36,6 +47,11 @@ export class CommandExecutor {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const spawnOptions: any = {
         stdio: ['pipe', 'pipe', 'pipe'],
+        // Merge per-call credentials on top of the current environment so that
+        // the spawned process sees them as ordinary env vars. This is safe:
+        // values are held only in memory for the duration of the spawn setup
+        // and are never written to disk or logged.
+        env: credentials ? { ...process.env, ...credentials } : process.env,
       };
 
       // Set working directory if provided

--- a/packages/core/src/executors/function-executor.ts
+++ b/packages/core/src/executors/function-executor.ts
@@ -25,10 +25,21 @@ export class FunctionExecutor {
   }
 
   /**
-   * Execute a tool that runs an async function
-   * Supports both embedded code and external .ts/.js files
+   * Execute a tool that runs an async function.
+   * Supports both embedded code and external .ts/.js files.
+   *
+   * @param tool - Tool definition
+   * @param params - Tool parameters
+   * @param credentials - Optional per-call credential overrides passed as `context.credentials`
+   *   to the tool function. The function can use them with:
+   *   `const token = context?.credentials?.MY_TOKEN ?? process.env.MY_TOKEN;`
+   *   Values are never logged. Falls back to undefined when not provided.
    */
-  async execute(tool: ToolDefinition, params: Record<string, unknown>): Promise<unknown> {
+  async execute(
+    tool: ToolDefinition,
+    params: Record<string, unknown>,
+    credentials?: Record<string, string>
+  ): Promise<unknown> {
     if (tool.execution.type !== 'function') {
       throw new MatimoError('Tool execution type is not function', ErrorCode.EXECUTION_FAILED, {
         expectedType: 'function',
@@ -140,9 +151,10 @@ export class FunctionExecutor {
           import(fileUrl)
             .then((module) => {
               const fn = (module.default || module) as (
-                input: Record<string, unknown>
+                input: Record<string, unknown>,
+                context?: { credentials?: Record<string, string> }
               ) => Promise<unknown>;
-              const result = fn(params);
+              const result = fn(params, credentials ? { credentials } : undefined);
 
               // Handle both Promise and non-Promise returns
               if (result instanceof Promise) {

--- a/packages/core/src/executors/http-executor.ts
+++ b/packages/core/src/executors/http-executor.ts
@@ -10,9 +10,21 @@ import { MatimoError, ErrorCode, fromHttpError } from '../errors/matimo-error';
 
 export class HttpExecutor {
   /**
-   * Execute a tool that makes an HTTP request
+   * Execute a tool that makes an HTTP request.
+   *
+   * @param tool - Tool definition
+   * @param params - Tool parameters (already env-injected by MatimoInstance)
+   * @param credentials - Optional per-call credential overrides. Used for
+   *   `authentication.type: basic` (username_env / password_env keys) instead of
+   *   reading from `process.env`. Other auth schemes (bearer, api_key) are handled
+   *   upstream via parameter templating in MatimoInstance.injectAuthParameters().
+   *   Values are never logged.
    */
-  async execute(tool: ToolDefinition, params: Record<string, unknown>): Promise<unknown> {
+  async execute(
+    tool: ToolDefinition,
+    params: Record<string, unknown>,
+    credentials?: Record<string, string>
+  ): Promise<unknown> {
     if (tool.execution.type !== 'http') {
       throw new MatimoError('Tool execution type is not http', ErrorCode.EXECUTION_FAILED, {
         expectedType: 'http',
@@ -57,7 +69,8 @@ export class HttpExecutor {
     // Natively handle HTTP Basic Auth when authentication.type === 'basic' and
     // username_env/password_env are declared. This eliminates the need for
     // developers to pre-compute base64 credentials as a separate env var step.
-    this.applyBasicAuth(tool, templatedHeaders as Record<string, string>);
+    // Credentials override takes precedence over process.env when provided.
+    this.applyBasicAuth(tool, templatedHeaders as Record<string, string>, credentials);
     const templatedBody =
       body && typeof body === 'object'
         ? this.templateObject(body as Record<string, unknown>, finalParams, tool.parameters)
@@ -133,15 +146,28 @@ export class HttpExecutor {
    * This is a zero-friction pattern: developers only set two natural env vars
    * (e.g. TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN) and Matimo handles encoding.
    * No pre-computed base64 credential string required.
+   *
+   * When `credentials` is provided the lookup order is:
+   *   1. `credentials[envVarName]`  (per-call override — multi-tenant use)
+   *   2. `process.env[envVarName]`  (singleton / single-tenant fallback)
+   *
+   * Credential values are never logged or included in error details.
    */
-  private applyBasicAuth(tool: ToolDefinition, headers: Record<string, string>): void {
+  private applyBasicAuth(
+    tool: ToolDefinition,
+    headers: Record<string, string>,
+    credentials?: Record<string, string>
+  ): void {
     const auth = tool.authentication;
     if (auth?.type !== 'basic' || !auth.username_env || !auth.password_env) {
       return;
     }
 
-    const username = process.env[auth.username_env];
-    const password = process.env[auth.password_env];
+    // Prefer per-call credentials, fall back to process.env
+    const username =
+      (credentials && credentials[auth.username_env]) ?? process.env[auth.username_env];
+    const password =
+      (credentials && credentials[auth.password_env]) ?? process.env[auth.password_env];
 
     if (!username || !password) {
       throw new MatimoError(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export type {
   RateLimitConfig,
   ErrorHandlingConfig,
   ToolDefinition,
+  ExecuteOptions,
 } from './core/types';
 export { ParameterSchema, AuthConfigSchema, ExecutionConfigSchema } from './core/schema';
 export { ToolLoader } from './core/tool-loader';

--- a/packages/core/src/matimo-instance.ts
+++ b/packages/core/src/matimo-instance.ts
@@ -240,13 +240,21 @@ export class MatimoInstance {
       }
 
       const credentials = options?.credentials;
+      const timeoutOverride = options?.timeout;
 
       // Auto-inject authentication parameters. When per-call credentials are
       // supplied they take precedence over process.env (multi-tenant support).
       const finalParams = this.injectAuthParameters(tool, params, credentials);
 
-      const executor = this.getExecutor(tool);
-      const result = await executor.execute(tool, finalParams, credentials);
+      // Apply per-call timeout override if provided. Create a shallow copy so the
+      // registered tool definition is never mutated between calls.
+      const effectiveTool =
+        timeoutOverride !== undefined
+          ? { ...tool, execution: { ...tool.execution, timeout: timeoutOverride } }
+          : tool;
+
+      const executor = this.getExecutor(effectiveTool);
+      const result = await executor.execute(effectiveTool, finalParams, credentials);
 
       this.logger.debug(`Tool executed successfully: ${toolName}`, {
         toolName,

--- a/packages/core/src/matimo-instance.ts
+++ b/packages/core/src/matimo-instance.ts
@@ -14,6 +14,7 @@ import {
   setGlobalMatimoLogger,
 } from './logging';
 import { ApprovalHandler, getGlobalApprovalHandler } from './approval/approval-handler';
+import type { ExecuteOptions } from './core/types';
 
 /**
  * Options for MatimoInstance initialization
@@ -162,12 +163,23 @@ export class MatimoInstance {
   }
 
   /**
-   * Execute a tool by name with parameters
+   * Execute a tool by name with parameters.
+   *
    * @param toolName - Name of the tool to execute
    * @param params - Tool parameters
+   * @param options - Optional execution options
+   * @param options.timeout - Execution timeout in milliseconds
+   * @param options.credentials - Per-call credential overrides (multi-tenant support).
+   *   Keys must match the env-var names the tool references (e.g. `SLACK_BOT_TOKEN`).
+   *   When provided, they take precedence over `process.env` for that single call.
+   *   Values are never logged and held in memory only for the duration of the call.
    * @returns Tool execution result
    */
-  async execute(toolName: string, params: Record<string, unknown>): Promise<unknown> {
+  async execute(
+    toolName: string,
+    params: Record<string, unknown>,
+    options?: ExecuteOptions
+  ): Promise<unknown> {
     const tool = this.registry.get(toolName);
     if (!tool) {
       const availableTools = this.registry.getAll().map((t) => t.name);
@@ -227,11 +239,14 @@ export class MatimoInstance {
         this.logger.info(`Destructive operation approved: ${toolName}`, { toolName });
       }
 
-      // Auto-inject authentication parameters from environment variables
-      const finalParams = this.injectAuthParameters(tool, params);
+      const credentials = options?.credentials;
+
+      // Auto-inject authentication parameters. When per-call credentials are
+      // supplied they take precedence over process.env (multi-tenant support).
+      const finalParams = this.injectAuthParameters(tool, params, credentials);
 
       const executor = this.getExecutor(tool);
-      const result = await executor.execute(tool, finalParams);
+      const result = await executor.execute(tool, finalParams, credentials);
 
       this.logger.debug(`Tool executed successfully: ${toolName}`, {
         toolName,
@@ -292,26 +307,89 @@ export class MatimoInstance {
   }
 
   /**
+   * Return the credential key names that a tool expects.
+   *
+   * This lets multi-tenant callers know exactly what to put in `options.credentials`
+   * without having to read the tool's YAML definition.
+   *
+   * The returned strings are the keys you pass to `execute()`:
+   * ```typescript
+   * const keys = matimo.getRequiredCredentials('slack-send-message');
+   * // → ['SLACK_BOT_TOKEN']
+   *
+   * // Then collect from your secrets store:
+   * const credentials = Object.fromEntries(
+   *   keys.map(k => [k, tenant.secrets[k]])
+   * );
+   * await matimo.execute('slack-send-message', params, { credentials });
+   * ```
+   *
+   * @param toolName - Exact tool name
+   * @returns Array of credential key names (may be empty if the tool needs no auth)
+   * @throws `MatimoError(TOOL_NOT_FOUND)` if the tool doesn't exist
+   */
+  getRequiredCredentials(toolName: string): string[] {
+    const tool = this.registry.get(toolName);
+    if (!tool) {
+      throw new MatimoError(`Tool '${toolName}' not found in registry`, ErrorCode.TOOL_NOT_FOUND, {
+        toolName,
+        availableTools: this.registry.getAll().map((t) => t.name),
+      });
+    }
+
+    const authPatterns = [
+      'token',
+      'key',
+      'secret',
+      'password',
+      'credential',
+      'auth',
+      'bearer',
+      'api_key',
+    ];
+
+    const referencedParams = this.extractParameterPlaceholders(tool);
+    const credentialKeys: string[] = [];
+
+    for (const paramName of referencedParams) {
+      const lowerName = paramName.toLowerCase();
+      if (authPatterns.some((pattern) => lowerName.includes(pattern))) {
+        credentialKeys.push(paramName);
+      }
+    }
+
+    // Also include basic-auth env var names declared in authentication config
+    const auth = tool.authentication;
+    if (auth?.type === 'basic') {
+      if (auth.username_env && !credentialKeys.includes(auth.username_env)) {
+        credentialKeys.push(auth.username_env);
+      }
+      if (auth.password_env && !credentialKeys.includes(auth.password_env)) {
+        credentialKeys.push(auth.password_env);
+      }
+    }
+
+    return credentialKeys;
+  }
+
+  /**
    * Automatically inject parameters from environment variables
    * Uses a YAML-native, scale-friendly approach:
    *
    * 1. Scans the execution config for all parameter placeholders
    * 2. For each parameter not provided by user, checks if it looks like auth (TOKEN, KEY, SECRET, etc.)
-   * 3. If yes, attempts to load from environment: MATIMO_<PARAM_NAME> or <PARAM_NAME>
+   * 3. If yes, attempts to load from (in order of priority):
+   *    a. `credentials[paramName]`          — per-call override (multi-tenant)
+   *    b. `credentials[MATIMO_${paramName}]` — prefixed per-call override
+   *    c. `process.env[MATIMO_${paramName}]` — prefixed env var
+   *    d. `process.env[paramName]`           — direct env var
    *
-   * This works for ANY tool with ANY auth parameter name - no hardcoding needed.
-   * Scales to unlimited tools - contributors just submit YAML.
-   *
-   * Examples:
-   * - GMAIL_ACCESS_TOKEN → looks in env vars
-   * - GITHUB_TOKEN → looks in env vars
-   * - SLACK_BOT_TOKEN → looks in env vars
-   * - MY_CUSTOM_API_KEY → looks in env vars
-   * - ANY_SECRET → looks in env vars
+   * Credential values are never logged.
    */
   private injectAuthParameters(
     tool: ToolDefinition,
-    params: Record<string, unknown>
+    params: Record<string, unknown>,
+    credentials?: Record<string, string>
   ): Record<string, unknown> {
     const result = { ...params };
 
@@ -341,18 +419,23 @@ export class MatimoInstance {
       const isAuthParam = authPatterns.some((pattern) => lowerName.includes(pattern));
 
       if (isAuthParam) {
-        // Try to load from environment
-        // First try MATIMO_ prefixed version for organization
-        let envValue = process.env[`MATIMO_${paramName}`];
+        // Lookup order:
+        // 1. Per-call credentials (multi-tenant override — never touches process.env)
+        // 2. Per-call credentials with MATIMO_ prefix
+        // 3. Environment variable with MATIMO_ prefix
+        // 4. Environment variable with the exact param name
+        let resolvedValue: string | undefined;
 
-        // If not found, try the parameter name directly
-        if (!envValue) {
-          envValue = process.env[paramName];
+        if (credentials) {
+          resolvedValue = credentials[paramName] ?? credentials[`MATIMO_${paramName}`];
         }
 
-        // If found, inject it
-        if (envValue) {
-          result[paramName] = envValue;
+        if (!resolvedValue) {
+          resolvedValue = process.env[`MATIMO_${paramName}`] ?? process.env[paramName];
+        }
+
+        if (resolvedValue) {
+          result[paramName] = resolvedValue;
         }
       }
     }

--- a/packages/core/test/unit/credentials-override.test.ts
+++ b/packages/core/test/unit/credentials-override.test.ts
@@ -477,6 +477,86 @@ describe('ExecuteOptions – type export', () => {
   });
 });
 
+// ─── options.timeout override ─────────────────────────────────────────────────
+
+describe('MatimoInstance.execute() – options.timeout override', () => {
+  let instance: MatimoInstance;
+  const toolsPath = require('path').join(__dirname, '../fixtures/tools');
+
+  beforeAll(async () => {
+    instance = await MatimoInstance.init(toolsPath);
+  });
+
+  it('should apply options.timeout to the HTTP executor request config', async () => {
+    // Spy on axios.request to capture the resolved config
+    const requestSpy = jest.spyOn(axios, 'request').mockResolvedValue({
+      status: 200,
+      data: { ok: true },
+    });
+
+    try {
+      await instance.execute('http-with-auth', { API_KEY: 'k', query: 'q' }, { timeout: 7500 });
+    } catch {
+      // result shape mismatch is acceptable; we only need the spy call
+    }
+
+    const config = requestSpy.mock.calls[0]?.[0] as { timeout?: number } | undefined;
+    expect(config?.timeout).toBe(7500);
+
+    requestSpy.mockRestore();
+  });
+
+  it('should use the tool YAML timeout when options.timeout is not provided', async () => {
+    const requestSpy = jest.spyOn(axios, 'request').mockResolvedValue({
+      status: 200,
+      data: { ok: true },
+    });
+
+    try {
+      await instance.execute('http-with-auth', { API_KEY: 'k', query: 'q' });
+    } catch {
+      // acceptable
+    }
+
+    const config = requestSpy.mock.calls[0]?.[0] as { timeout?: number } | undefined;
+    // http-with-auth fixture has no explicit timeout in YAML → axios config timeout
+    // should be undefined (not overridden to 7500)
+    expect(config?.timeout).not.toBe(7500);
+
+    requestSpy.mockRestore();
+  });
+
+  it('should not mutate the registered tool definition when timeout override is applied', async () => {
+    const toolBefore = instance.getTool('http-with-auth');
+    const originalTimeout =
+      toolBefore?.execution && 'timeout' in toolBefore.execution
+        ? (toolBefore.execution as { timeout?: number }).timeout
+        : undefined;
+
+    const requestSpy = jest.spyOn(axios, 'request').mockResolvedValue({
+      status: 200,
+      data: { ok: true },
+    });
+
+    try {
+      await instance.execute('http-with-auth', { API_KEY: 'k', query: 'q' }, { timeout: 9999 });
+    } catch {
+      // acceptable
+    }
+
+    const toolAfter = instance.getTool('http-with-auth');
+    const afterTimeout =
+      toolAfter?.execution && 'timeout' in toolAfter.execution
+        ? (toolAfter.execution as { timeout?: number }).timeout
+        : undefined;
+
+    // Registry copy must be unchanged
+    expect(afterTimeout).toBe(originalTimeout);
+
+    requestSpy.mockRestore();
+  });
+});
+
 // ─── getRequiredCredentials() ─────────────────────────────────────────────────
 
 describe('MatimoInstance.getRequiredCredentials()', () => {

--- a/packages/core/test/unit/credentials-override.test.ts
+++ b/packages/core/test/unit/credentials-override.test.ts
@@ -1,0 +1,564 @@
+/**
+ * Tests for per-execution credential override (options.credentials)
+ *
+ * Covers:
+ * - HttpExecutor: Basic Auth via credentials instead of process.env
+ * - CommandExecutor: credentials injected as child-process env vars
+ * - FunctionExecutor: credentials forwarded as context.credentials
+ * - MatimoInstance.execute(): credential threading + injectAuthParameters priority
+ * - Backward compatibility: no credentials → existing env-var behaviour unchanged
+ * - Partial credentials: only some keys provided, rest fall back to env
+ * - Security: credential values never surface in error messages
+ */
+
+import axios from 'axios';
+import { spawn } from 'child_process';
+import { HttpExecutor } from '../../src/executors/http-executor';
+import { CommandExecutor } from '../../src/executors/command-executor';
+import { FunctionExecutor } from '../../src/executors/function-executor';
+import { MatimoInstance } from '../../src/matimo-instance';
+import { MatimoError, ErrorCode } from '../../src/errors/matimo-error';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+const mockedSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+// Helper: create a minimal fake EventEmitter-like child process
+function makeFakeChild(exitCode = 0, stdoutData = '{"ok":true}') {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const on = jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+    listeners[event] = listeners[event] || [];
+    listeners[event].push(cb);
+    return child;
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const child: any = {
+    stdout: { on: jest.fn() },
+    stderr: { on: jest.fn() },
+    on,
+    kill: jest.fn(),
+    _emit: (event: string, ...args: unknown[]) => {
+      (listeners[event] || []).forEach((cb) => cb(...args));
+    },
+    _emitData: (data: string) => {
+      // Trigger 'data' on stdout
+      const stdoutListeners = (child.stdout.on as jest.Mock).mock.calls;
+      stdoutListeners.forEach(([event, cb]: [string, (d: Buffer) => void]) => {
+        if (event === 'data') cb(Buffer.from(data));
+      });
+    },
+  };
+
+  // Auto-emit close after the Promise chain resolves (setImmediate)
+  child.stdout.on.mockImplementation((event: string, cb: (d: Buffer) => void) => {
+    if (event === 'data') setTimeout(() => cb(Buffer.from(stdoutData)), 0);
+    return child.stdout;
+  });
+  child.stderr.on.mockImplementation(() => child.stderr);
+  child.on.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+    if (event === 'close') setTimeout(() => cb(exitCode), 5);
+    return child;
+  });
+
+  return child;
+}
+
+// ─── HttpExecutor ─────────────────────────────────────────────────────────────
+
+describe('HttpExecutor – credential override', () => {
+  let executor: HttpExecutor;
+
+  beforeEach(() => {
+    executor = new HttpExecutor();
+    jest.clearAllMocks();
+  });
+
+  const basicAuthTool = {
+    name: 'basic-auth-tool',
+    version: '1.0.0',
+    description: 'Tool using Basic Auth',
+    parameters: {},
+    execution: {
+      type: 'http' as const,
+      method: 'GET' as const,
+      url: 'https://api.example.com/data',
+    },
+    authentication: {
+      type: 'basic' as const,
+      username_env: 'MY_USERNAME',
+      password_env: 'MY_PASSWORD',
+    },
+  };
+
+  it('should use credentials for Basic Auth instead of process.env', async () => {
+    // Ensure env vars are NOT set so any failure means credentials weren't used
+    delete process.env.MY_USERNAME;
+    delete process.env.MY_PASSWORD;
+
+    mockedAxios.request.mockResolvedValue({ status: 200, data: { ok: true } });
+
+    await executor.execute(
+      basicAuthTool,
+      {},
+      {
+        MY_USERNAME: 'tenant-user',
+        MY_PASSWORD: 'tenant-pass',
+      }
+    );
+
+    const callArgs = mockedAxios.request.mock.calls[0][0];
+    const expectedAuth = Buffer.from('tenant-user:tenant-pass').toString('base64');
+    expect((callArgs.headers as Record<string, string>).Authorization).toBe(
+      `Basic ${expectedAuth}`
+    );
+  });
+
+  it('should fall back to process.env when no credentials provided (backward compat)', async () => {
+    process.env.MY_USERNAME = 'env-user';
+    process.env.MY_PASSWORD = 'env-pass';
+
+    mockedAxios.request.mockResolvedValue({ status: 200, data: { ok: true } });
+
+    // No credentials argument — old API
+    await executor.execute(basicAuthTool, {});
+
+    const callArgs = mockedAxios.request.mock.calls[0][0];
+    const expectedAuth = Buffer.from('env-user:env-pass').toString('base64');
+    expect((callArgs.headers as Record<string, string>).Authorization).toBe(
+      `Basic ${expectedAuth}`
+    );
+
+    delete process.env.MY_USERNAME;
+    delete process.env.MY_PASSWORD;
+  });
+
+  it('should prefer credentials over process.env when both are set', async () => {
+    process.env.MY_USERNAME = 'env-user';
+    process.env.MY_PASSWORD = 'env-pass';
+
+    mockedAxios.request.mockResolvedValue({ status: 200, data: { ok: true } });
+
+    await executor.execute(
+      basicAuthTool,
+      {},
+      {
+        MY_USERNAME: 'override-user',
+        MY_PASSWORD: 'override-pass',
+      }
+    );
+
+    const callArgs = mockedAxios.request.mock.calls[0][0];
+    const expectedAuth = Buffer.from('override-user:override-pass').toString('base64');
+    expect((callArgs.headers as Record<string, string>).Authorization).toBe(
+      `Basic ${expectedAuth}`
+    );
+
+    delete process.env.MY_USERNAME;
+    delete process.env.MY_PASSWORD;
+  });
+
+  it('should throw AUTH_FAILED if neither credentials nor env vars are set', async () => {
+    delete process.env.MY_USERNAME;
+    delete process.env.MY_PASSWORD;
+
+    let caught: unknown;
+    try {
+      await executor.execute(basicAuthTool, {});
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    expect((caught as MatimoError).code).toBe(ErrorCode.AUTH_FAILED);
+
+    // Env-var NAMES may appear in the error message (helpful for debugging)
+    // but no SECRET VALUES should be present (there are none here to leak)
+    const errorText = JSON.stringify(caught);
+    // Confirm the error is about missing credentials, not something unrelated
+    expect(errorText).toContain('AUTH_FAILED');
+  });
+
+  it('should execute normally without authentication config (no credentials needed)', async () => {
+    const noAuthTool = {
+      name: 'no-auth-tool',
+      version: '1.0.0',
+      description: 'No auth required',
+      parameters: {},
+      execution: {
+        type: 'http' as const,
+        method: 'GET' as const,
+        url: 'https://api.example.com/public',
+      },
+    };
+
+    mockedAxios.request.mockResolvedValue({ status: 200, data: { result: 'ok' } });
+
+    const result = (await executor.execute(noAuthTool, {}, { SOME_TOKEN: 'value' })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── CommandExecutor ──────────────────────────────────────────────────────────
+
+describe('CommandExecutor – credential override', () => {
+  let executor: CommandExecutor;
+
+  beforeEach(() => {
+    executor = new CommandExecutor('/tmp');
+    jest.clearAllMocks();
+  });
+
+  const echoTool = {
+    name: 'echo-tool',
+    version: '1.0.0',
+    description: 'Echo test tool',
+    parameters: {},
+    execution: {
+      type: 'command' as const,
+      command: 'echo',
+      args: ['hello'],
+      timeout: 5000,
+    },
+  };
+
+  it('should inject credentials as env vars into the child process', async () => {
+    mockedSpawn.mockReturnValue(makeFakeChild(0, 'done'));
+
+    await executor.execute(
+      echoTool,
+      {},
+      {
+        SLACK_BOT_TOKEN: 'xoxb-tenant-a',
+        API_KEY: 'secret-key',
+      }
+    );
+
+    const spawnCall = mockedSpawn.mock.calls[0];
+    const spawnOptions = spawnCall[2] as { env?: Record<string, string> };
+
+    expect(spawnOptions.env).toBeDefined();
+    expect(spawnOptions.env!.SLACK_BOT_TOKEN).toBe('xoxb-tenant-a');
+    expect(spawnOptions.env!.API_KEY).toBe('secret-key');
+    // Should still include existing process.env variables
+    expect(spawnOptions.env!.PATH).toBe(process.env.PATH);
+  });
+
+  it('should use process.env (no extra keys) when credentials not provided (backward compat)', async () => {
+    mockedSpawn.mockReturnValue(makeFakeChild(0, 'done'));
+
+    await executor.execute(echoTool, {});
+
+    const spawnCall = mockedSpawn.mock.calls[0];
+    const spawnOptions = spawnCall[2] as { env?: Record<string, string> };
+
+    // When no credentials given, env should be process.env itself
+    expect(spawnOptions.env).toBe(process.env);
+  });
+
+  it('should let credentials override process.env values for same key', async () => {
+    process.env.SLACK_BOT_TOKEN = 'original-env-token';
+    mockedSpawn.mockReturnValue(makeFakeChild(0, 'done'));
+
+    await executor.execute(echoTool, {}, { SLACK_BOT_TOKEN: 'overridden-token' });
+
+    const spawnCall = mockedSpawn.mock.calls[0];
+    const spawnOptions = spawnCall[2] as { env?: Record<string, string> };
+
+    expect(spawnOptions.env!.SLACK_BOT_TOKEN).toBe('overridden-token');
+
+    delete process.env.SLACK_BOT_TOKEN;
+  });
+});
+
+// ─── FunctionExecutor ─────────────────────────────────────────────────────────
+
+describe('FunctionExecutor – credential override', () => {
+  it('should pass credentials as context.credentials to external tool function', async () => {
+    // We test the call shape rather than running real dynamically-imported code by
+    // inspecting the executor behaviour through a mock import.
+    // Since dynamic imports aren't easily intercepted in Jest, we verify that
+    // execute() accepts credentials without throwing and that the param is threaded.
+    const executor = new FunctionExecutor('/tmp');
+
+    const tool = {
+      name: 'fn-tool',
+      version: '1.0.0',
+      description: 'Function tool',
+      parameters: {},
+      execution: {
+        type: 'function' as const,
+        code: './nonexistent-file.ts',
+        timeout: 1000,
+      },
+      _definitionPath: '/tmp/tools/fn-tool/definition.yaml',
+    };
+
+    // The file doesn't exist → expect a rejection (not a crash from missing credentials param)
+    const result = (await executor.execute(
+      tool,
+      { msg: 'hello' },
+      {
+        MY_TOKEN: 'ctx-token',
+      }
+    )) as Record<string, unknown>;
+
+    // Resolves with error object (FunctionExecutor never throws, always resolves)
+    expect(result.success).toBe(false);
+    // Error should be about file-not-found, not about missing credentials parameter
+    expect(typeof result.error).toBe('string');
+  });
+
+  it('should work without credentials (backward compat)', async () => {
+    const executor = new FunctionExecutor('/tmp');
+
+    const tool = {
+      name: 'fn-tool-no-creds',
+      version: '1.0.0',
+      description: 'No creds',
+      parameters: {},
+      execution: {
+        type: 'function' as const,
+        code: './nonexistent.ts',
+        timeout: 1000,
+      },
+      _definitionPath: '/tmp/tools/fn-tool-no-creds/definition.yaml',
+    };
+
+    // Should not crash regardless of whether credentials arg is passed
+    const result = (await executor.execute(tool, {})) as Record<string, unknown>;
+    expect(result.success).toBe(false);
+    expect(typeof result.error).toBe('string');
+  });
+});
+
+// ─── MatimoInstance.execute() ─────────────────────────────────────────────────
+
+describe('MatimoInstance.execute() – credential override', () => {
+  let instance: MatimoInstance;
+  const toolsPath = require('path').join(__dirname, '../fixtures/tools');
+
+  beforeAll(async () => {
+    instance = await MatimoInstance.init(toolsPath);
+  });
+
+  afterEach(() => {
+    // Clean auth-related env vars to prevent leakage between tests
+    delete process.env.GMAIL_ACCESS_TOKEN;
+    delete process.env.MATIMO_GMAIL_ACCESS_TOKEN;
+    delete process.env.SLACK_BOT_TOKEN;
+  });
+
+  it('should accept execute() options without credentials (backward compat)', async () => {
+    // execute() with no options at all — must not throw a TypeError
+    await expect(instance.execute('non-existent-tool', {})).rejects.toThrow('not found');
+  });
+
+  it('should accept execute() with empty credentials object without throwing', async () => {
+    await expect(instance.execute('non-existent-tool', {}, { credentials: {} })).rejects.toThrow(
+      'not found'
+    );
+  });
+
+  it('should use credentials to inject auth params instead of process.env', async () => {
+    // Ensure env is clean so the injection MUST come from credentials
+    delete process.env.GMAIL_ACCESS_TOKEN;
+    delete process.env.MATIMO_GMAIL_ACCESS_TOKEN;
+
+    // gmail-send-email expects GMAIL_ACCESS_TOKEN in the Authorization header
+    // With credentials it should try to make an HTTP call (which will fail at
+    // network level or schema validation) — NOT at the auth-injection layer.
+    // We're confirming it advances past auth injection.
+    try {
+      await instance.execute(
+        'gmail-send-email',
+        { to: 'user@example.com', subject: 'Hi', body: 'Test' },
+        { credentials: { GMAIL_ACCESS_TOKEN: 'tenant-gmail-token' } }
+      );
+    } catch (err) {
+      // Should NOT fail with "missing token" style message — the token was supplied
+      const msg = (err as Error).message ?? '';
+      expect(msg).not.toMatch(/token.*required|auth.*required/i);
+    }
+  });
+
+  it('should fall back to process.env when credentials are not provided', async () => {
+    process.env.MATIMO_GMAIL_ACCESS_TOKEN = 'env-token-fallback';
+
+    // Without credentials the env-var injection must still work
+    try {
+      await instance.execute('gmail-send-email', {
+        to: 'user@example.com',
+        subject: 'Test',
+        body: 'Test',
+      });
+    } catch (err) {
+      // Error should be something other than missing auth
+      const msg = (err as Error).message ?? '';
+      expect(msg).not.toMatch(/token.*required|auth.*required/i);
+    }
+
+    delete process.env.MATIMO_GMAIL_ACCESS_TOKEN;
+  });
+
+  it('should handle partial credentials (provided key takes priority; others fall back to env)', async () => {
+    process.env.SLACK_BOT_TOKEN = 'env-slack-token';
+    delete process.env.GMAIL_ACCESS_TOKEN;
+
+    // Only GMAIL_ACCESS_TOKEN provided in credentials; SLACK_BOT_TOKEN falls back to env
+    // We simply verify that execute resolves/rejects without a TypeError
+    try {
+      await instance.execute(
+        'gmail-send-email',
+        { to: 'a@b.com', subject: 'hello', body: 'world' },
+        { credentials: { GMAIL_ACCESS_TOKEN: 'per-call-gmail-token' } }
+      );
+    } catch {
+      // expected
+    }
+
+    // Env token still intact (credentials are never written to process.env)
+    expect(process.env.SLACK_BOT_TOKEN).toBe('env-slack-token');
+  });
+
+  it('should not modify process.env when credentials are provided', async () => {
+    const originalEnv = { ...process.env };
+
+    try {
+      await instance.execute(
+        'non-existent-tool',
+        {},
+        { credentials: { SECRET_KEY: 'should-not-leak', API_TOKEN: 'never-persist' } }
+      );
+    } catch {
+      // expected — tool not found
+    }
+
+    // process.env must be unchanged
+    expect(process.env.SECRET_KEY).toBeUndefined();
+    expect(process.env.API_TOKEN).toBeUndefined();
+    expect(Object.keys(process.env)).toEqual(Object.keys(originalEnv));
+  });
+
+  it('credential values should not appear in error messages', async () => {
+    try {
+      await instance.execute(
+        'non-existent-tool',
+        {},
+        { credentials: { MY_SECRET: 'ultra-secret-value-abc123' } }
+      );
+    } catch (err) {
+      const errorStr = JSON.stringify(err) + (err as Error).message;
+      expect(errorStr).not.toContain('ultra-secret-value-abc123');
+    }
+  });
+});
+
+// ─── ExecuteOptions type export ───────────────────────────────────────────────
+
+describe('ExecuteOptions – type export', () => {
+  it('should be a valid TypeScript type (compile-time check)', () => {
+    // Import at the type level; runtime presence confirmed by the test file compiling
+    // and importing MatimoInstance at the top of this file without errors.
+    // If ExecuteOptions were missing from the public API this file would not compile.
+    type TestOptions = import('../../src/core/types').ExecuteOptions;
+    const opts: TestOptions = { timeout: 1000, credentials: { KEY: 'val' } };
+    expect(opts.timeout).toBe(1000);
+    expect(opts.credentials?.KEY).toBe('val');
+  });
+});
+
+// ─── getRequiredCredentials() ─────────────────────────────────────────────────
+
+describe('MatimoInstance.getRequiredCredentials()', () => {
+  let instance: MatimoInstance;
+  const toolsPath = require('path').join(__dirname, '../fixtures/tools');
+
+  beforeAll(async () => {
+    instance = await MatimoInstance.init(toolsPath);
+  });
+
+  it('should return auth-key names for a tool that uses a bearer token', () => {
+    // complex-body-tool has {token} in its Authorization header and body
+    const keys = instance.getRequiredCredentials('complex-body-tool');
+    expect(keys).toContain('token');
+  });
+
+  it('should return auth-key names for a tool that uses an API key', () => {
+    // http-with-auth has {API_KEY} in headers and query params
+    const keys = instance.getRequiredCredentials('http-with-auth');
+    expect(keys).toContain('API_KEY');
+  });
+
+  it('should return an empty array for a tool with no auth parameters', () => {
+    // edge-case-tool only has {value1} and {value2} — no auth patterns
+    const keys = instance.getRequiredCredentials('edge-case-tool');
+    expect(keys).toEqual([]);
+  });
+
+  it('should return only auth-related keys, not regular user parameters', () => {
+    // complex-body-tool has name/email/phone (user params) and token (auth)
+    const keys = instance.getRequiredCredentials('complex-body-tool');
+    expect(keys).not.toContain('name');
+    expect(keys).not.toContain('email');
+    expect(keys).not.toContain('phone');
+    expect(keys).not.toContain('tags');
+    expect(keys).toContain('token');
+  });
+
+  it('should throw TOOL_NOT_FOUND for an unknown tool', () => {
+    expect(() => instance.getRequiredCredentials('no-such-tool')).toThrow(MatimoError);
+    try {
+      instance.getRequiredCredentials('no-such-tool');
+    } catch (err) {
+      expect((err as MatimoError).code).toBe(ErrorCode.TOOL_NOT_FOUND);
+    }
+  });
+
+  it('result can be used directly to build a credentials map', async () => {
+    // This verifies the primary DX use-case: discover → collect → execute
+    const keys = instance.getRequiredCredentials('complex-body-tool');
+    const fakeVault: Record<string, string> = { token: 'my-secret-token' };
+
+    const credentials = Object.fromEntries(keys.map((k) => [k, fakeVault[k] ?? '']));
+
+    // The correct credential key was discovered and mapped from the vault
+    expect(credentials).toEqual({ token: 'my-secret-token' });
+
+    // Passing these to execute() must not throw a TypeError or schema error on the
+    // credentials shape itself (network errors are fine and expected here)
+    let threw = false;
+    try {
+      await instance.execute(
+        'complex-body-tool',
+        { name: 'Alice', email: 'alice@example.com' },
+        { credentials }
+      );
+    } catch (e) {
+      if (e instanceof TypeError) threw = true;
+    }
+    expect(threw).toBe(false);
+  });
+
+  it('should return consistent results on repeated calls (deterministic)', () => {
+    const keys1 = instance.getRequiredCredentials('http-with-auth');
+    const keys2 = instance.getRequiredCredentials('http-with-auth');
+    expect(keys1).toEqual(keys2);
+  });
+
+  it('should include basic-auth env var names from authentication config', () => {
+    // Verify getRequiredCredentials is callable and doesn't throw.
+    // The username_env/password_env branch of the implementation is covered by the
+    // HttpExecutor basic-auth tests above; here we confirm the method is stable.
+    expect(() => instance.getRequiredCredentials('http-with-auth')).not.toThrow();
+  });
+});

--- a/packages/core/test/unit/matimo-instance.test.ts
+++ b/packages/core/test/unit/matimo-instance.test.ts
@@ -1,4 +1,5 @@
 import { MatimoInstance } from '../../src/matimo-instance';
+import { getGlobalApprovalHandler } from '../../src/approval/approval-handler';
 import path from 'path';
 
 describe('MatimoInstance - Core Functionality', () => {
@@ -292,5 +293,175 @@ describe('MatimoInstance - Core Functionality', () => {
 
       expect(instance1.getAllTools().length).toBe(instance2.getAllTools().length);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch coverage for lines not reached by the tests above
+// ---------------------------------------------------------------------------
+
+// Typed helpers to access private internals without `any`
+type InstanceWithPrivates = {
+  registry: { register: (tool: Record<string, unknown>) => void };
+  scanObjectForParams: (obj: unknown, params: Set<string>) => void;
+  getExecutor: (tool: Record<string, unknown>) => unknown;
+};
+type HandlerWithPrivates = {
+  approvalCallback: ((req: unknown) => Promise<boolean>) | null;
+};
+
+describe('MatimoInstance – branch coverage', () => {
+  let instance: MatimoInstance;
+  const toolsPath = path.join(__dirname, '../fixtures/tools');
+
+  beforeAll(async () => {
+    instance = await MatimoInstance.init(toolsPath);
+
+    // Inject a command-type tool (no fixture exists) to cover the command scan
+    // branch (line 216) and getExecutor 'command' case (line 552).
+    (instance as unknown as InstanceWithPrivates).registry.register({
+      name: 'test-command-scan-tool',
+      version: '1.0.0',
+      description: 'Fake command tool for branch coverage',
+      parameters: { command: { type: 'string', required: true } },
+      execution: { type: 'command' as const, command: 'echo', args: ['{command}'] },
+    });
+
+    // Inject a basic-auth tool to cover getRequiredCredentials lines 364-368.
+    (instance as unknown as InstanceWithPrivates).registry.register({
+      name: 'test-basic-auth-tool',
+      version: '1.0.0',
+      description: 'Basic auth tool for credential detection coverage',
+      parameters: {},
+      execution: {
+        type: 'http' as const,
+        method: 'GET' as const,
+        url: 'https://api.example.com/data',
+      },
+      authentication: {
+        type: 'basic' as const,
+        username_env: 'SERVICE_ACCOUNT_SID',
+        password_env: 'SERVICE_AUTH_TOKEN',
+      },
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.MATIMO_APPROVAL_SCAN_ALL_PARAMS;
+    // Reset any approval callback set by individual tests
+    (getGlobalApprovalHandler() as unknown as HandlerWithPrivates).approvalCallback = null;
+  });
+
+  // -------------------------------------------------------------------------
+  // Lines 216 – scanContent = params.command  (command-type tool)
+  // Line  552 – return this.commandExecutor   (getExecutor 'command' case)
+  // -------------------------------------------------------------------------
+  it('should scan params.command for command-type tools and route to CommandExecutor', async () => {
+    // Non-destructive command value → approval not triggered, echo executes
+    await expect(
+      instance.execute('test-command-scan-tool', { command: 'hello world' })
+    ).resolves.toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Line 218 – scanContent = params.sql  (HTTP tool, params.sql provided)
+  // -------------------------------------------------------------------------
+  it('should scan params.sql for destructive keywords on any tool type', async () => {
+    // Non-destructive SQL → scan runs, no approval, execution proceeds then fails at HTTP
+    try {
+      await instance.execute('http-with-auth', { API_KEY: 'test', query: 'test', sql: 'SELECT 1' });
+    } catch {
+      // HTTP failure expected; we just need line 218 reached
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Lines 220-224 – MATIMO_APPROVAL_SCAN_ALL_PARAMS=true path
+  // -------------------------------------------------------------------------
+  it('should scan all string params when MATIMO_APPROVAL_SCAN_ALL_PARAMS=true', async () => {
+    process.env.MATIMO_APPROVAL_SCAN_ALL_PARAMS = 'true';
+    try {
+      await instance.execute('http-with-auth', { API_KEY: 'test', query: 'find something' });
+    } catch {
+      // HTTP failure expected; lines 220-224 already reached
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Lines 233-239 – approval callback invoked for destructive content
+  // -------------------------------------------------------------------------
+  it('should invoke approval callback when destructive content is detected', async () => {
+    const handler = getGlobalApprovalHandler();
+    const captured: string[] = [];
+    handler.setApprovalCallback(async (req) => {
+      captured.push(req.toolName);
+      return true; // approve
+    });
+
+    try {
+      await instance.execute('http-with-auth', {
+        API_KEY: 'test',
+        query: 'test',
+        sql: 'DELETE FROM users', // destructive keyword → triggers approval
+      });
+    } catch {
+      // HTTP failure after approval is fine
+    }
+
+    expect(captured).toContain('http-with-auth');
+  });
+
+  // -------------------------------------------------------------------------
+  // Lines 364-368 – getRequiredCredentials: basic-auth username_env/password_env
+  // -------------------------------------------------------------------------
+  it('should include username_env and password_env from basic-auth config', () => {
+    const keys = instance.getRequiredCredentials('test-basic-auth-tool');
+    expect(keys).toContain('SERVICE_ACCOUNT_SID');
+    expect(keys).toContain('SERVICE_AUTH_TOKEN');
+  });
+
+  // -------------------------------------------------------------------------
+  // Line 509 – scanObjectForParams early return for non-objects
+  // -------------------------------------------------------------------------
+  it('should return early without throwing when scanObjectForParams receives a non-object', () => {
+    const params = new Set<string>();
+    const priv = instance as unknown as InstanceWithPrivates;
+    expect(() => {
+      priv.scanObjectForParams('a string', params);
+      priv.scanObjectForParams(null, params);
+      priv.scanObjectForParams(undefined, params);
+      priv.scanObjectForParams(42, params);
+    }).not.toThrow();
+    expect(params.size).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Line 514 – scanObjectForParams circular reference detection
+  // -------------------------------------------------------------------------
+  it('should handle circular object references without infinite recursion', () => {
+    const params = new Set<string>();
+    const obj: Record<string, unknown> = { token: '{ACCESS_TOKEN}' };
+    obj.self = obj; // circular reference
+
+    expect(() => {
+      (instance as unknown as InstanceWithPrivates).scanObjectForParams(obj, params);
+    }).not.toThrow();
+    expect(params.has('ACCESS_TOKEN')).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Line 558 – getExecutor default: unsupported execution type
+  // -------------------------------------------------------------------------
+  it('should throw MatimoError for unsupported execution types', () => {
+    const fakeTool = {
+      name: 'unsupported',
+      version: '1.0.0',
+      description: 'test',
+      parameters: {},
+      execution: { type: 'graphql' },
+    };
+    expect(() => {
+      (instance as unknown as InstanceWithPrivates).getExecutor(fakeTool);
+    }).toThrow('Unsupported execution type: graphql');
   });
 });

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/github",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "GitHub API tools for Matimo - Full-featured GitHub integration with OAuth2 and PAT support",
   "type": "module",
   "files": [

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/gmail",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Gmail tools for Matimo",
   "type": "module",
   "files": [

--- a/packages/hubspot/package.json
+++ b/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/hubspot",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "HubSpot tools for Matimo - universal CRM, marketing, and automation integration.",
   "type": "module",
   "files": ["tools", "README.md", "definition.yaml"],

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/mailchimp",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Mailchimp email marketing tools for Matimo — manage audiences, subscribers, and campaigns",
   "type": "module",
   "files": [

--- a/packages/notion/package.json
+++ b/packages/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/notion",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Notion workspace tools for Matimo",
   "type": "module",
   "files": [

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/postgres",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Postgres tools for Matimo",
   "type": "module",
   "files": [

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/slack",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Slack workspace tools for Matimo",
   "type": "module",
   "files": [

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/twilio",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.12.1",
   "description": "Twilio messaging tools for Matimo — send SMS, MMS, and manage messages",
   "type": "module",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@langchain/openai':
         specifier: ^1.2.4
         version: 1.2.5(@langchain/core@1.1.19)
+      '@matimo/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@matimo/github':
         specifier: workspace:*
         version: link:../../packages/github


### PR DESCRIPTION
## Description

This pull request patch release for the new per-execution credential override feature and introduces a developer helper for credential discovery. It also updates the documentation to reflect these changes and adds a comprehensive example for multi-tenant credential management.

**Major features and documentation updates:**

*Per-execution credential override and DX improvements:*
- Added support for passing credentials per `execute()` call via the new `ExecuteOptions.credentials` parameter in the SDK, enabling multi-tenant use-cases without mutating `process.env`. This is fully backward compatible. [[1]](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aR1-R71) [[2]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718L83-R105) [[3]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718R145-R266)
- Introduced `getRequiredCredentials(toolName)` helper, which returns the exact credential keys needed by a tool, simplifying multi-tenant credential management and discovery. [[1]](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aR1-R71) [[2]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718R10) [[3]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718R145-R266)

*Examples and test coverage:*
- Added a runnable example in `examples/tools/credentials/credentials-example.ts` demonstrating per-tenant credential injection, process.env isolation, credential manifest building, and fallback behavior.
- Updated test coverage stats and described new tests for credential override and related paths, achieving 100% line/statement coverage on the core package. [[1]](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aR1-R71) [[2]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L16-R23)

*Release process and documentation:*
- Updated all relevant docs (`RELEASES.md`, `ROADMAP.md`, `SDK.md`) to reflect the new features, test coverage, and release process. [[1]](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aR1-R71) [[2]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L5-R5) [[3]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L16-R23) [[4]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L193-R198) [[5]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2R212) [[6]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718R10) [[7]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718L83-R105) [[8]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718L103-L119) [[9]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718R145-R266)
- Bumped example and package versions to v0.1.0-alpha.12.1. [[1]](diffhunk://#diff-f2c9d4c6bdb5d05cb52f0458679812336845d3e8b660d4140bef84ea4a8e16b1L3-R3) [[2]](diffhunk://#diff-a9142841c8e3e0381b55da730778fae99b309031f9b7ea759ffc0be6e0cdc7ddL3-R3) [[3]](diffhunk://#diff-a9142841c8e3e0381b55da730778fae99b309031f9b7ea759ffc0be6e0cdc7ddR51)

No breaking changes are introduced; all existing code remains compatible.

---

**References:**  
[[1]](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aR1-R71) [[2]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718R10) [[3]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718L83-R105) [[4]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718L103-L119) [[5]](diffhunk://#diff-e9b83308eb0510a59524e16d2526e29af8c46ebdb6220cb6f1424016af450718R145-R266) [[6]](diffhunk://#diff-0fa9bdf40cfb0a8fc56d03fc9a5b3d8ac6ba6c1baf6435d8e8230197e87db1f3R1-R221) [[7]](diffhunk://#diff-f2c9d4c6bdb5d05cb52f0458679812336845d3e8b660d4140bef84ea4a8e16b1L3-R3) [[8]](diffhunk://#diff-a9142841c8e3e0381b55da730778fae99b309031f9b7ea759ffc0be6e0cdc7ddL3-R3) [[9]](diffhunk://#diff-a9142841c8e3e0381b55da730778fae99b309031f9b7ea759ffc0be6e0cdc7ddR51) [[10]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L5-R5) [[11]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L16-R23) [[12]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L193-R198) [[13]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2R212)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Tool addition
- [ ] Tool modification

## Testing
- [ ] Tests added
- [ ] All tests passing
- [ ] Coverage maintained (>90%)

## Checklist
- [ ] Code formatted (`pnpm format`)
- [ ] Linting passes (`pnpm lint`)
- [ ] Tests passing (`pnpm test`)
- [ ] Documentation updated
- [ ] No console.log statements
- [ ] No hardcoded secrets
- [ ] Tool YAML validated (if applicable)

## Related Issues
Closes #[issue number]
