### PR TITLE
fix(mcp): avoid trusting client approval flags

### DIFF
--- a/python/packages/core/src/matimo/mcp/README.md
+++ b/python/packages/core/src/matimo/mcp/README.md
@@ -172,10 +172,13 @@ async def _call_tool(self, name: str, arguments: dict) -> list:
     if tool_def and tool_def.requires_approval and not matimo_approved:
         return [TextContent(type="text", text="Approval required. Re-invoke with _matimo_approved: true")]
     
-    # Safe to execute
-    result = await self._matimo.execute(name, clean_args, approved=matimo_approved)
+    # The client-supplied flag is a confirmation signal only by default.
+    result = await self._matimo.execute(name, clean_args, approved=False)
     return [TextContent(type="text", text=json.dumps(result))]
 ```
+
+Only set `MCPServerOptions(trust_client_approval=True)` when the transport or
+embedding application provides a server-trusted approval signal.
 
 ---
 
@@ -529,7 +532,7 @@ uv run pytest packages/core/tests/unit/test_mcp_server.py -v
 3. **Credentials stored in memory only** — never written to process.env or disk
 4. **Secrets per-call injection** — only passed to `matimo.execute()`, not to clients
 5. **Bearer token for HTTP** — required in `Authorization` header for HTTP transport
-6. **Approval gating** — destructive tools require explicit `_matimo_approved=true`
+6. **Approval gating** — destructive tools require explicit `_matimo_approved=true`, then server-side approval still applies by default
 
 ---
 

--- a/python/packages/core/src/matimo/mcp/server.py
+++ b/python/packages/core/src/matimo/mcp/server.py
@@ -54,6 +54,10 @@ class MCPServerOptions:
     untrusted_paths: list[str] | None = None
     approval_secret: str | None = None
     approval_dir: str | None = None
+    # Trust _matimo_approved from MCP tool-call arguments as an out-of-band
+    # approval. Defaults to False because MCP arguments are supplied by the
+    # client/model and are not a server-side approval signal by themselves.
+    trust_client_approval: bool = False
 
 
 class MCPServer:
@@ -287,8 +291,9 @@ class MCPServer:
         except ImportError:
             return []
 
-        # Extract _matimo_approved flag before forwarding to execute.
-        # Mirrors: const { _matimo_approved, ...cleanArgs } = args in TS.
+        # Extract _matimo_approved before forwarding to execute. By default this
+        # client-supplied flag is only a confirmation prompt signal; it must not
+        # bypass server-side approval checks.
         matimo_approved: object = arguments.get("_matimo_approved", False)
         clean_args = {k: v for k, v in arguments.items() if k != "_matimo_approved"}
 
@@ -319,7 +324,11 @@ class MCPServer:
                 name,
                 clean_args,
                 credentials=credentials or None,
-                approved=matimo_approved is True,
+                approved=(
+                    self._options.trust_client_approval
+                    and bool(tool_def and getattr(tool_def, "requires_approval", False))
+                    and matimo_approved is True
+                ),
             )
             output = _json.dumps(result, indent=2, default=str)
             return [mcp_types.TextContent(type="text", text=output)]

--- a/python/packages/core/tests/unit/test_mcp_server.py
+++ b/python/packages/core/tests/unit/test_mcp_server.py
@@ -334,8 +334,8 @@ class TestMCPServerCallTool:
         # execute must NOT have been called
         matimo.execute.assert_not_awaited()
 
-    async def test_call_tool_approval_required_with_flag(self) -> None:
-        """Tools with requires_approval=True execute when _matimo_approved=True."""
+    async def test_call_tool_does_not_trust_approval_flag_by_default(self) -> None:
+        """_matimo_approved=True must not bypass server-side approval by default."""
         mock_mcp_types = MagicMock()
         mock_mcp_types.TextContent.return_value = MagicMock()
 
@@ -346,6 +346,30 @@ class TestMCPServerCallTool:
         matimo.get_tool.return_value = tool
         matimo.execute = AsyncMock(return_value={"ok": True})
         server = MCPServer(matimo, MCPServerOptions())
+
+        with patch.dict("sys.modules", {"mcp": MagicMock(), "mcp.types": mock_mcp_types}):
+            result = await server._call_tool("dangerous_tool", {"_matimo_approved": True})
+
+        assert len(result) == 1
+        matimo.execute.assert_awaited_once()
+        _, kwargs = matimo.execute.await_args
+        assert kwargs.get("approved") is False
+
+    async def test_call_tool_trusts_approval_flag_only_when_configured(self) -> None:
+        """Servers can opt in to trusting transport-level approval confirmation."""
+        mock_mcp_types = MagicMock()
+        mock_mcp_types.TextContent.return_value = MagicMock()
+
+        tool = _make_tool("dangerous_tool")
+        object.__setattr__(tool, "requires_approval", True)
+
+        matimo = _make_matimo_mock()
+        matimo.get_tool.return_value = tool
+        matimo.execute = AsyncMock(return_value={"ok": True})
+        server = MCPServer(
+            matimo,
+            MCPServerOptions(trust_client_approval=True),
+        )
 
         with patch.dict("sys.modules", {"mcp": MagicMock(), "mcp.types": mock_mcp_types}):
             result = await server._call_tool("dangerous_tool", {"_matimo_approved": True})

--- a/typescript/packages/core/src/mcp/mcp-server.ts
+++ b/typescript/packages/core/src/mcp/mcp-server.ts
@@ -71,6 +71,12 @@ export interface MCPServerOptions {
   approvalSecret?: string;
   /** Directory for .matimo-approvals.json. */
   approvalDir?: string;
+  /**
+   * Trust `_matimo_approved: true` from MCP tool-call arguments as an
+   * out-of-band approval. Defaults to false because MCP arguments are supplied
+   * by the client/model and are not a server-side approval signal by themselves.
+   */
+  trustClientApproval?: boolean;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────
@@ -453,12 +459,14 @@ export class MCPServer {
               }
 
               // Strip _matimo_approved from args before passing to execute.
-              // When MCP already confirmed approval, pass a per-execution
-              // approval override so MatimoInstance.execute() doesn't
-              // re-prompt via the interactive handler.
+              // By default this client-supplied flag is only a confirmation
+              // prompt signal; it must not bypass server-side approval checks.
               const { _matimo_approved, ...cleanArgs } = args;
               const result = await matimo.execute(tool.name, cleanArgs, {
-                approved: _matimo_approved === true,
+                approved:
+                  this.options.trustClientApproval === true &&
+                  tool.requires_approval === true &&
+                  _matimo_approved === true,
                 credentials: this.resolvedSecrets,
               });
 

--- a/typescript/packages/core/test/unit/mcp/mcp-server.test.ts
+++ b/typescript/packages/core/test/unit/mcp/mcp-server.test.ts
@@ -443,7 +443,7 @@ describe('MCPServer', () => {
       await server.stop();
     });
 
-    it('should execute approval-required tools with _matimo_approved', async () => {
+    it('should not trust _matimo_approved as server approval by default', async () => {
       const tool = createTestTool({
         name: 'dangerous_delete',
         requires_approval: true,
@@ -452,6 +452,38 @@ describe('MCPServer', () => {
       mockExecute.mockResolvedValue({ deleted: true });
 
       const server = new MCPServer({ transport: 'stdio', autoDiscover: false });
+      await server.start();
+
+      const callback = mockRegisterTool.mock.calls[0][2];
+      const result = await callback({ message: 'delete all', _matimo_approved: true });
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify({ deleted: true }, null, 2) }],
+      });
+      expect(mockExecute).toHaveBeenCalledWith(
+        'dangerous_delete',
+        {
+          message: 'delete all',
+        },
+        { approved: false, credentials: {} }
+      );
+
+      await server.stop();
+    });
+
+    it('should trust _matimo_approved only when explicitly configured', async () => {
+      const tool = createTestTool({
+        name: 'dangerous_delete',
+        requires_approval: true,
+      });
+      mockListTools.mockReturnValue([tool]);
+      mockExecute.mockResolvedValue({ deleted: true });
+
+      const server = new MCPServer({
+        transport: 'stdio',
+        autoDiscover: false,
+        trustClientApproval: true,
+      });
       await server.start();
 
       const callback = mockRegisterTool.mock.calls[0][2];


### PR DESCRIPTION
## Summary
- keep `_matimo_approved` as an MCP confirmation signal, but stop treating it as trusted server approval by default
- add explicit `trustClientApproval` / `trust_client_approval` server options for deployments with a trusted approval transport
- cover the default-safe and opt-in paths in both TypeScript and Python MCP server tests

Closes #69.

## Validation
- `pnpm test -- packages/core/test/unit/mcp/mcp-server.test.ts --runInBand`
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm exec prettier --check packages/core/src/mcp/mcp-server.ts packages/core/test/unit/mcp/mcp-server.test.ts`
- `pnpm exec eslint packages/core/src/mcp/mcp-server.ts packages/core/test/unit/mcp/mcp-server.test.ts`
- `uv run --with pytest-asyncio --with 'mcp>=1.0' --with uvicorn pytest tests/unit/test_mcp_server.py -q`
- `uv run --with ruff ruff check src/matimo/mcp/server.py tests/unit/test_mcp_server.py`
- `git diff --check`