### PR TITLE
Release/v0.1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: python
 
       - name: Lint
-        run: uv tool run ruff check packages/
+        run: uv run ruff check packages/
         working-directory: python
 
       - name: Type check

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -40,7 +40,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Lint (ruff)
-        run: uv tool run ruff check packages/
+        run: uv run ruff check packages/
 
       - name: Type check (mypy)
         run: uv run mypy packages/ || true   # non-blocking: union type refinement work in progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [v0.1.7] - 2026-08-11
+
+### ✨ Features
+- `@matimo/composio`: 5 new Google Workspace toolkits — Gmail (23 tools), Google Sheets (36), Google Docs (32), Google Forms (7), Google Meet (9) — growing the generated catalog from 342 to 449 tools across 9 to 14 toolkits
+
+### 📚 Documentation
+- Document `@matimo/composio`'s bring-your-own-key (BYOK) credential model, with a non-affiliation disclaimer and links to Composio's Terms of Service and Privacy Policy, in the package README and `docs/COMPOSIO.md`
+- Add `THIRD_PARTY_NOTICES.md` listing every third-party provider Matimo can connect to, its credential env var, and a link to that provider's own terms
+- Mandate the BYOK pattern for all future third-party connectors in `CONTRIBUTING.md` and `SECURITY.md`
+- Update `docs/COMPOSIO.md` toolkit table and tool counts (342 → 449 tools, 9 → 14 toolkits)
+
+### 🧪 Testing
+- Exercise the new Gmail toolkit across all four example patterns (factory, decorator, LangChain, HITL-approval)
+- Give HITL integration tests headroom above Jest's 5000ms default — they drive a real `type: command` child-process spawn plus approval-manifest disk I/O with no prior margin, which could exceed the default under CI load
+
+### 🐛 Bug Fixes
+- Add the missing `license: MIT` field to provider sub-package manifests, silencing an npm/pnpm publish warning
+- Pin CI to `uv run ruff` (locked `0.15.9`) instead of the floating `uv tool run ruff`, which pulled an unpinned version and flagged findings never enforced for these packages
+
+### 📦 Version Bumps
+- All 13 `typescript/` packages (`core`, `cli`, `bruno`, `slack`, `gmail`, `github`, `hubspot`, `notion`, `mailchimp`, `microsoft`, `postgres`, `twilio`, `composio`): `0.1.6` → `0.1.7`
+
+---
 ## [v0.1.1.post1] - 2026-05-12
 
 ### 🐛 Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -524,7 +524,7 @@ bring-your-own-key (BYOK) / bring-your-own-account model:
 - The credential (API key, OAuth client ID/secret, connected-account ID,
   etc.) is always supplied at runtime by whoever deploys or configures
   Matimo — via an environment variable or tool parameter — never hardcoded,
-  never a Matimo-owned/shared account, and never proxied through
+  never a Matimo-owned/shared account, and never routed through
   Matimo-operated infrastructure.
 - Grep the tool's `definition.yaml` and any executor code for literal
   secrets before opening a PR; only `{ENV_VAR}` placeholders and
@@ -533,8 +533,8 @@ bring-your-own-key (BYOK) / bring-your-own-account model:
 - Add an entry to [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) for
   the new provider: package name, credential env var(s), and a link to that
   provider's own Terms of Service.
-- If the connector is a thin proxy over another platform's catalog (the way
-  `@matimo/composio` proxies Composio), state that plainly in the package
+- If the connector is a thin wrapper over another platform's catalog (the way
+  `@matimo/composio` wraps Composio), state that plainly in the package
   README along with a non-affiliation disclaimer — see
   [`typescript/packages/composio/README.md`](./typescript/packages/composio/README.md)
   for the pattern to follow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -515,6 +515,36 @@ output_schema:
       type: number
 ```
 
+## Third-Party Connectors — Credential Policy (BYOK)
+
+Every provider package that talks to an external API or platform (Slack,
+Composio, HubSpot, a future Stripe/Zendesk/etc. connector) **must** follow a
+bring-your-own-key (BYOK) / bring-your-own-account model:
+
+- The credential (API key, OAuth client ID/secret, connected-account ID,
+  etc.) is always supplied at runtime by whoever deploys or configures
+  Matimo — via an environment variable or tool parameter — never hardcoded,
+  never a Matimo-owned/shared account, and never proxied through
+  Matimo-operated infrastructure.
+- Grep the tool's `definition.yaml` and any executor code for literal
+  secrets before opening a PR; only `{ENV_VAR}` placeholders and
+  `notes.env` references should appear (see
+  [SECURITY.md § Never Hardcode Secrets](./SECURITY.md#2-never-hardcode-secrets)).
+- Add an entry to [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) for
+  the new provider: package name, credential env var(s), and a link to that
+  provider's own Terms of Service.
+- If the connector is a thin proxy over another platform's catalog (the way
+  `@matimo/composio` proxies Composio), state that plainly in the package
+  README along with a non-affiliation disclaimer — see
+  [`typescript/packages/composio/README.md`](./typescript/packages/composio/README.md)
+  for the pattern to follow.
+
+This exists because Matimo's own MIT license only governs Matimo's source
+code — it says nothing about, and doesn't excuse anyone from, the terms of
+whatever third-party service a tool connects to. Keeping every connector on
+a BYOK model means that compliance relationship stays directly between the
+end user and the provider, where it belongs.
+
 ## AI/Vibe-Coded PRs
 
 Welcome! 🤖 Built with Claude, ChatGPT, or other AI tools? **Awesome!** Just mark it:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Matimo ships with built-in support for:
 - **Postgres Tools**: Query/modify data with safety checks
 - **Twilio Tools**: Send SMS/MMS, manage messages
 - **Mailchimp Tools**: Audiences, subscribers, email campaigns
-- **Composio Catalog (Governed)**: 449 tools across Asana, Jira, Linear, Google Workspace, Microsoft 365, and more — proxied through [Composio](https://composio.dev) with Matimo's policy engine and HITL layered on top ([why](./typescript/packages/composio/README.md#-credit-where-its-due))
+- **Composio Catalog (Governed)**: 449 tools across Asana, Jira, Linear, Google Workspace, Microsoft 365, and more — routed through [Composio](https://composio.dev) with Matimo's policy engine and HITL layered on top ([why](./typescript/packages/composio/README.md#-credit-where-its-due))
 - **Auto-Discovery**: Automatic detection of `@matimo/*` providers from npm
 - **Matimo CLI**: Tool discovery, setup wizard, MCP config generation
 - **OAuth2 Support**: Provider-agnostic authorization for Slack, Gmail, GitHub, etc.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Matimo ships with built-in support for:
 - **Postgres Tools**: Query/modify data with safety checks
 - **Twilio Tools**: Send SMS/MMS, manage messages
 - **Mailchimp Tools**: Audiences, subscribers, email campaigns
+- **Composio Catalog (Governed)**: 449 tools across Asana, Jira, Linear, Google Workspace, Microsoft 365, and more — proxied through [Composio](https://composio.dev) with Matimo's policy engine and HITL layered on top ([why](./typescript/packages/composio/README.md#-credit-where-its-due))
 - **Auto-Discovery**: Automatic detection of `@matimo/*` providers from npm
 - **Matimo CLI**: Tool discovery, setup wizard, MCP config generation
 - **OAuth2 Support**: Provider-agnostic authorization for Slack, Gmail, GitHub, etc.
@@ -394,6 +395,20 @@ See [Adding Tools to Matimo](./docs/tool-development/ADDING_TOOLS.md) for the co
 - [Contributing](./CONTRIBUTING.md)
 
 ---
+
+## Acknowledgments
+
+Broad integration coverage (Asana, Jira, Linear, Google Workspace, Microsoft
+365, and more — 449 tools total) is made possible today by
+[Composio](https://composio.dev), whose catalog `@matimo/composio` wraps with
+Matimo's policy engine, risk classification, and HITL approval. Building and
+maintaining native, fully-tested first-party tools for that many actions
+ourselves would take far longer than agents should have to wait for governed
+access — so we lean on Composio's integration breadth as a deliberate,
+temporary bridge while we grow native `@matimo/<provider>` packages for the
+highest-usage toolkits over time. See
+[the composio package README](./typescript/packages/composio/README.md#-credit-where-its-due)
+for the full rationale.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -428,6 +428,25 @@ authentication:
   secret_env_var: MATIMO_OAUTH_TOKEN
 ```
 
+### Third-Party Credentials — Always BYOK
+
+All four methods above share one rule: the credential value always comes
+from the deploying application's own environment (`secret_env_var`), never
+from a value baked into a tool definition or shipped in a Matimo package.
+This isn't only a secrets-hygiene rule — it's also how Matimo keeps every
+provider connector on a bring-your-own-key model, so the compliance
+relationship with that provider (their Terms of Service, Fair Usage Policy,
+data handling) stays directly between the end user and the provider, not
+routed through any Matimo-operated account or infrastructure.
+
+`@matimo/composio` is the clearest example: every `composio_*` tool requires
+a caller-supplied `COMPOSIO_API_KEY` plus a `composio_connected_account_id`
+obtained through Composio's own OAuth flow — see
+[`docs/COMPOSIO.md`](./docs/COMPOSIO.md) and
+[`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md). Before adding a new
+third-party connector, see
+[CONTRIBUTING.md § Third-Party Connectors — Credential Policy](./CONTRIBUTING.md#third-party-connectors--credential-policy-byok).
+
 ---
 
 ## Command Execution

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,60 @@
+# Third-Party Notices
+
+Matimo (`matimo` core + `@matimo/*` provider packages) is MIT-licensed. That
+license governs Matimo's own source code — it does not extend to, and has no
+bearing on, the terms of any third-party API or platform a Matimo tool
+connects to. **Matimo is not affiliated with, endorsed by, or sponsored by
+any provider listed below.** Provider names are used solely to describe
+interoperability.
+
+Every credential below is supplied at runtime by the person or application
+deploying Matimo (bring-your-own-key / bring-your-own-account) — Matimo does
+not embed, proxy through, or hold its own account with any of these
+providers. **Users are responsible for independently reading and complying
+with each provider's own Terms of Service, Privacy Policy, and API/Fair
+Usage policies before connecting it to Matimo.**
+
+| Provider | Matimo package | Credential(s) (env var) | Provider's terms |
+|---|---|---|---|
+| [Composio](https://composio.dev) | `@matimo/composio` | `COMPOSIO_API_KEY` (+ per-toolkit connected account) | [Terms](https://composio.dev/terms) · [Privacy](https://composio.dev/privacy) |
+| [Slack](https://slack.com) | `@matimo/slack` | `SLACK_BOT_TOKEN` | [Slack API Terms](https://slack.com/terms-of-service/api) |
+| [Google (Gmail)](https://developers.google.com/gmail/api) | `@matimo/gmail` | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` (OAuth2) | [Google APIs Terms](https://developers.google.com/terms) |
+| [Microsoft](https://learn.microsoft.com/graph/) | `@matimo/microsoft` | `MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` (OAuth2) | [Microsoft APIs Terms of Use](https://learn.microsoft.com/legal/microsoft-apis/terms-of-use) |
+| [GitHub](https://github.com) | `@matimo/github` | `GITHUB_TOKEN` | [GitHub Terms of Service](https://docs.github.com/site-policy/github-terms/github-terms-of-service) |
+| [HubSpot](https://hubspot.com) | `@matimo/hubspot` | `MATIMO_HUBSPOT_API_KEY` | [HubSpot Legal](https://legal.hubspot.com/) |
+| [Notion](https://notion.so) | `@matimo/notion` | `NOTION_API_KEY` | [Notion API Terms](https://www.notion.so/notion-api-terms) |
+| [Mailchimp](https://mailchimp.com) | `@matimo/mailchimp` | `MAILCHIMP_API_KEY` | [Mailchimp Standard Terms of Use](https://mailchimp.com/legal/terms/) |
+| [Twilio](https://twilio.com) | `@matimo/twilio` | `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` | [Twilio Terms of Service](https://www.twilio.com/legal/tos) |
+| PostgreSQL (user-controlled infrastructure) | `@matimo/postgres` | Connection string, user-supplied | N/A — connects to infrastructure the user already controls, not a hosted third-party SaaS platform |
+
+## Composio specifically
+
+`@matimo/composio` proxies Composio's `/tools/execute/{slug}` REST endpoint
+to expose 449+ third-party actions (Asana, Jira, Linear, Google Workspace,
+Microsoft 365, and more) under Matimo's policy engine. See:
+
+- [`typescript/packages/composio/README.md`](./typescript/packages/composio/README.md) — rationale for the dependency and BYOK model
+- [`docs/COMPOSIO.md`](./docs/COMPOSIO.md) — usage reference
+
+## Generated catalog data
+
+Tool names, descriptions, and parameter schemas under
+`typescript/packages/composio/tools/composio_*/` were extracted from
+Composio's catalog API by `scripts/generate-tools.ts` and are redistributed
+as static files in the `@matimo/composio` package. This is a one-time,
+project-level extraction — distinct from the runtime BYOK credential each
+end user supplies to actually execute a tool.
+
+## No bundled third-party client libraries
+
+None of the packages above depend on a vendor-published client SDK
+(`composio-core`, `@slack/web-api`, etc.) — every provider integration in
+Matimo is implemented as a `type: http` YAML definition calling the
+provider's REST API directly, so there is no third-party library license to
+reconcile against Matimo's own MIT license.
+
+## Reporting an issue
+
+If you believe a listing here is inaccurate, missing, or that Matimo's use
+of a provider's API is inconsistent with that provider's terms, open an
+issue or see [SECURITY.md](./SECURITY.md) for responsible disclosure.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,7 +9,7 @@ interoperability.
 
 Every credential below is supplied at runtime by the person or application
 deploying Matimo (bring-your-own-key / bring-your-own-account) — Matimo does
-not embed, proxy through, or hold its own account with any of these
+not embed, route through, or hold its own account with any of these
 providers. **Users are responsible for independently reading and complying
 with each provider's own Terms of Service, Privacy Policy, and API/Fair
 Usage policies before connecting it to Matimo.**
@@ -29,7 +29,7 @@ Usage policies before connecting it to Matimo.**
 
 ## Composio specifically
 
-`@matimo/composio` proxies Composio's `/tools/execute/{slug}` REST endpoint
+`@matimo/composio` calls Composio's `/tools/execute/{slug}` REST endpoint
 to expose 449+ third-party actions (Asana, Jira, Linear, Google Workspace,
 Microsoft 365, and more) under Matimo's policy engine. See:
 

--- a/docs/COMPOSIO.md
+++ b/docs/COMPOSIO.md
@@ -8,7 +8,7 @@ nav_order: 4
 
 `@matimo/composio` turns [Composio](https://composio.dev)'s 250+ integrations from "agent has raw API access" into "agent has governed, auditable, human-approvable API access" — same breadth, with Matimo's policy engine, risk classification, and human-in-the-loop (HITL) approval layered on top.
 
-> **Bring your own key.** Every tool here requires *your own* `COMPOSIO_API_KEY` and Composio connected accounts, supplied at runtime — Matimo does not hold a Composio account or proxy requests through Matimo-operated infrastructure. You're responsible for complying with [Composio's Terms of Service](https://composio.dev/terms) and [Privacy Policy](https://composio.dev/privacy) independently. Matimo is not affiliated with, endorsed by, or sponsored by Composio. See [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) for the full list of third-party providers Matimo can connect to.
+> **Bring your own key.** Every tool here requires *your own* `COMPOSIO_API_KEY` and Composio connected accounts, supplied at runtime — Matimo does not hold a Composio account or route requests through Matimo-operated infrastructure. You're responsible for complying with [Composio's Terms of Service](https://composio.dev/terms) and [Privacy Policy](https://composio.dev/privacy) independently. Matimo is not affiliated with, endorsed by, or sponsored by Composio. See [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) for the full list of third-party providers Matimo can connect to.
 
 ---
 
@@ -64,14 +64,19 @@ Every generated tool is `type: http` — no custom executor code. `@matimo/compo
 | `one_drive` | `composio_one_drive_*` | 35 | `list_drives`, `download_file`, `search_items` |
 | `share_point` | `composio_share_point_*` | 6 | `create_folder`, `create_list`, `find_user` |
 | `microsoft_teams` | `composio_microsoft_teams_*` | 28 | `teams_list`, `teams_post_channel_message`, `create_meeting` |
+| `gmail` | `composio_gmail_*` | 23 | `send_email`, `fetch_emails`, `create_email_draft` |
+| `googlesheets` | `composio_googlesheets_*` | 36 | `batch_get`, `create_spreadsheet_row`, `create_chart` |
+| `googledocs` | `composio_googledocs_*` | 32 | `create_document`, `replace_all_text`, `insert_table_action` |
+| `googleforms` | `composio_googleforms_*` | 7 | `create_form`, `get_response`, `list_responses` |
+| `googlemeet` | `composio_googlemeet_*` | 9 | `create_meet`, `list_conference_records`, `get_transcripts_by_conference_record_id` |
 
-**Total: 342 tools** across 9 toolkits (as of v0.1.5). Add more toolkits by running the generator — see [Generating More Toolkits](#generating-more-toolkits).
+**Total: 449 tools** across 14 toolkits (as of v0.1.7). Add more toolkits by running the generator — see [Generating More Toolkits](#generating-more-toolkits).
 
 ---
 
 ## Every Tool Call Needs Three Things
 
-All 342 tools share the same three required inputs:
+All 449 tools share the same three required inputs:
 
 | Input | How it's supplied |
 |-------|-----------------|
@@ -191,7 +196,7 @@ See `typescript/examples/tools/composio/composio-with-approval.ts` for the full 
 
 ## LangChain Integration
 
-With 342 tools, loading all of them into a LangChain agent exceeds OpenAI's 128-tool limit. **Always filter to the toolkits relevant to the agent before binding:**
+With 449 tools, loading all of them into a LangChain agent exceeds OpenAI's 128-tool limit. **Always filter to the toolkits relevant to the agent before binding:**
 
 ```typescript
 import { MatimoInstance, convertToolsToLangChain, type ToolDefinition } from '@matimo/core';

--- a/docs/COMPOSIO.md
+++ b/docs/COMPOSIO.md
@@ -8,6 +8,8 @@ nav_order: 4
 
 `@matimo/composio` turns [Composio](https://composio.dev)'s 250+ integrations from "agent has raw API access" into "agent has governed, auditable, human-approvable API access" — same breadth, with Matimo's policy engine, risk classification, and human-in-the-loop (HITL) approval layered on top.
 
+> **Bring your own key.** Every tool here requires *your own* `COMPOSIO_API_KEY` and Composio connected accounts, supplied at runtime — Matimo does not hold a Composio account or proxy requests through Matimo-operated infrastructure. You're responsible for complying with [Composio's Terms of Service](https://composio.dev/terms) and [Privacy Policy](https://composio.dev/privacy) independently. Matimo is not affiliated with, endorsed by, or sponsored by Composio. See [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) for the full list of third-party providers Matimo can connect to.
+
 ---
 
 ## What Is Composio?

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,3 +1,33 @@
+## v0.1.7 — Composio Google Workspace Expansion: Gmail, Sheets, Docs, Forms, Meet 📇
+
+> **Release**: Five new Composio-backed Google Workspace toolkits (Gmail, Sheets, Docs, Forms, Meet) adding 107 governed tools, plus explicit BYOK compliance documentation for the Composio dependency, two small fixes, and a flaky-test timeout fix.
+
+**Released**: August 11, 2026
+**Scope**: `typescript/` workspace — all 13 packages (`core`, `cli`, `bruno`, `slack`, `gmail`, `github`, `hubspot`, `notion`, `mailchimp`, `microsoft`, `postgres`, `twilio`, `composio`) bumped to `0.1.7` in lockstep. Python untouched this release.
+**Severity**: 🟢 **Additive** — new tools and documentation only, no breaking changes to existing package APIs
+
+---
+
+### ✨ **Composio: 5 new Google Workspace toolkits**
+
+`@matimo/composio`'s generated catalog grows from 342 → 449 tools across 9 → 14 toolkits: Gmail (23), Google Sheets (36), Google Docs (32), Google Forms (7), and Google Meet (9). Same governed-access model as every other `composio_*` tool — bring-your-own `COMPOSIO_API_KEY` + `composio_connected_account_id`, risk-classified, policy-gated.
+
+### 🧪 **Gmail: example coverage**
+
+The new Gmail toolkit is exercised across all four example patterns (factory, decorator, LangChain, HITL-approval).
+
+### 📚 **Composio: BYOK & third-party notices**
+
+Documented `@matimo/composio`'s bring-your-own-key credential model explicitly: a non-affiliation disclaimer and links to Composio's Terms of Service and Privacy Policy were added to the package README and `docs/COMPOSIO.md`. Added `THIRD_PARTY_NOTICES.md`, listing every provider Matimo can connect to, its credential env var, and a link to that provider's own terms. `CONTRIBUTING.md` and `SECURITY.md` now mandate the BYOK pattern for all future third-party connectors, not just Composio.
+
+### 🐛 **Fixes**
+
+- Provider sub-package manifests were missing an explicit `license: MIT` field, silently triggering an npm/pnpm publish warning on everything but `core`
+- CI now pins `uv run ruff` (locked `0.15.9`) instead of the floating `uv tool run ruff`, which pulled an unpinned version and flagged findings never enforced for these packages
+- HITL integration tests (`matimo-instance-hitl-paths.test.ts`) given headroom above Jest's 5000ms default — they drive a real `type: command` child-process spawn plus approval-manifest disk I/O with no prior margin, which could exceed the default under CI load even though the logic itself was correct
+
+---
+
 ## v0.1.6 — Document & Web Tooling: web_scraper, convert_to_file, extract_from_file 🛠️
 
 > **Release**: Three new core tools for pulling content into an agent's context and turning agent output into shippable files, plus expression-mode calculator, a Gmail attachment tool, a Bruno bug fix, and a round of dependency security patches.

--- a/typescript/examples/tools/.env.example
+++ b/typescript/examples/tools/.env.example
@@ -2,6 +2,24 @@
 # Get your key from: https://platform.openai.com/api-keys
 # OPENAI_API_KEY=sk-your-api-key-here
 
+# Composio Example Configuration
+# Get your API key from: https://app.composio.dev -> Settings -> API Keys
+# Connect each toolkit via the Composio dashboard first, then copy its
+# connected account ID from Connections -> <toolkit> -> Connected Account ID.
+# COMPOSIO_API_KEY=your-composio-project-api-key
+# COMPOSIO_USER_ID=your-tenant-user-id
+# JIRA_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# GOOGLEDRIVE_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# GOOGLECALENDAR_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# MICROSOFT_TEAMS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# GMAIL_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# GMAIL_TEST_RECIPIENT_EMAIL=you@example.com
+# GOOGLESHEETS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# GOOGLEDOCS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# GOOGLEFORMS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+# GOOGLEFORMS_TEST_FORM_ID=your-google-form-id
+# GOOGLEMEET_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+
 # Gmail Example Configuration
 # Get your token from: https://developers.google.com/oauthplayground
 # GMAIL_ACCESS_TOKEN=<your-access-token-here>

--- a/typescript/examples/tools/composio/composio-decorator.ts
+++ b/typescript/examples/tools/composio/composio-decorator.ts
@@ -21,7 +21,8 @@
  * SETUP:
  * ─────────────────────────────────────────────────────────────────────────
  * Same as composio-factory.ts — set COMPOSIO_API_KEY, COMPOSIO_USER_ID,
- * and at least JIRA_CONNECTED_ACCOUNT_ID in your .env file.
+ * and at least one of JIRA_CONNECTED_ACCOUNT_ID, GOOGLEDRIVE_CONNECTED_ACCOUNT_ID,
+ * or GMAIL_CONNECTED_ACCOUNT_ID in your .env file.
  *
  * USAGE:
  * ─────────────────────────────────────────────────────────────────────────
@@ -125,11 +126,49 @@ class DriveAgent {
   }
 }
 
+/**
+ * Tenant-scoped Gmail agent.
+ */
+class GmailAgent {
+  private readonly userId: string;
+  private readonly accountId: string;
+
+  constructor(userId: string, accountId: string) {
+    this.userId = userId;
+    this.accountId = accountId;
+  }
+
+  @tool('composio_gmail_get_profile')
+  async getProfile(
+    composio_user_id: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+    composio_connected_account_id: string // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<unknown> {
+    return {};
+  }
+
+  @tool('composio_gmail_list_labels')
+  async listLabels(
+    composio_user_id: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+    composio_connected_account_id: string // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<unknown> {
+    return {};
+  }
+
+  async whoAmI(): Promise<unknown> {
+    return this.getProfile(this.userId, this.accountId);
+  }
+
+  async labels(): Promise<unknown> {
+    return this.listLabels(this.userId, this.accountId);
+  }
+}
+
 async function main(): Promise<void> {
   const apiKey = process.env.COMPOSIO_API_KEY;
   const userId = process.env.COMPOSIO_USER_ID || '';
   const jiraAccountId = process.env.JIRA_CONNECTED_ACCOUNT_ID || '';
   const driveAccountId = process.env.GOOGLEDRIVE_CONNECTED_ACCOUNT_ID || '';
+  const gmailAccountId = process.env.GMAIL_CONNECTED_ACCOUNT_ID || '';
 
   if (!apiKey || !userId) {
     console.error('\n❌ COMPOSIO_API_KEY and COMPOSIO_USER_ID are required');
@@ -166,6 +205,20 @@ async function main(): Promise<void> {
     console.info('✅ list files:', JSON.stringify(files, null, 2));
   } else {
     console.info('\n⚠️  Skipping Google Drive (GOOGLEDRIVE_CONNECTED_ACCOUNT_ID not set)');
+  }
+
+  // ── Gmail agent ────────────────────────────────────────────────────────────
+  if (gmailAccountId) {
+    console.info('\n─── Gmail (via GmailAgent class) ────────────────────────────────');
+    const gmail = new GmailAgent(userId, gmailAccountId);
+
+    const profile = await gmail.whoAmI();
+    console.info('✅ getProfile:', JSON.stringify(profile, null, 2));
+
+    const labels = await gmail.labels();
+    console.info('✅ list labels:', JSON.stringify(labels, null, 2));
+  } else {
+    console.info('\n⚠️  Skipping Gmail (GMAIL_CONNECTED_ACCOUNT_ID not set)');
   }
 
   console.info('\n' + '='.repeat(70));

--- a/typescript/examples/tools/composio/composio-factory.ts
+++ b/typescript/examples/tools/composio/composio-factory.ts
@@ -9,9 +9,9 @@
  * The simplest way to call Composio-backed tools. One line per tool call —
  * no classes, no LLM, no abstraction layer.
  *
- * @matimo/composio wraps Composio's 250+ integrations (Jira, Google Drive,
- * Microsoft Teams, Outlook, SharePoint, and more) with Matimo's policy
- * engine, risk classification, and human-in-the-loop approval layer.
+ * @matimo/composio wraps Composio's 250+ integrations (Jira, Google
+ * Workspace, Microsoft Teams, Outlook, SharePoint, and more) with Matimo's
+ * policy engine, risk classification, and human-in-the-loop approval layer.
  *
  * Use this pattern when:
  * ✅ Writing scripts, one-off data pipelines, or CLI tools
@@ -21,7 +21,8 @@
  * SETUP:
  * ─────────────────────────────────────────────────────────────────────────
  * 1. Obtain a Composio API key at https://app.composio.dev
- *    and connect your accounts (Jira, Google Drive, etc.) via the dashboard.
+ *    and connect your accounts (Jira, Google Drive, Gmail, etc.) via the
+ *    dashboard.
  *
  * 2. Create a .env file at the root of typescript/examples/tools/:
  *    COMPOSIO_API_KEY=your-composio-project-api-key
@@ -29,9 +30,16 @@
  *    JIRA_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
  *    GOOGLEDRIVE_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
  *    MICROSOFT_TEAMS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+ *    GMAIL_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+ *    GOOGLESHEETS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+ *    GOOGLEDOCS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+ *    GOOGLEFORMS_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
+ *    GOOGLEFORMS_TEST_FORM_ID=your-google-form-id
+ *    GOOGLEMEET_CONNECTED_ACCOUNT_ID=ca_xxxxxxxxxx
  *
  *    Connected account IDs are shown in the Composio dashboard under
- *    Connections → <toolkit> → Connected Account ID.
+ *    Connections → <toolkit> → Connected Account ID. Each section below is
+ *    skipped automatically if its connected account ID is not set.
  *
  * USAGE:
  * ─────────────────────────────────────────────────────────────────────────
@@ -39,10 +47,15 @@
  *
  * TOOLS DEMONSTRATED:
  * ─────────────────────────────────────────────────────────────────────────
- * • composio_jira_get_current_user        (risk: low)
- * • composio_googledrive_list_files       (risk: low)
- * • composio_googlecalendar_list_calendars (risk: low)
- * • composio_microsoft_teams_teams_list   (risk: low)
+ * • composio_jira_get_current_user           (risk: low)
+ * • composio_googledrive_list_files          (risk: low)
+ * • composio_googlecalendar_list_calendars   (risk: low)
+ * • composio_microsoft_teams_teams_list      (risk: low)
+ * • composio_gmail_get_profile               (risk: low)
+ * • composio_googlesheets_search_spreadsheets (risk: low)
+ * • composio_googledocs_search_documents     (risk: low)
+ * • composio_googleforms_get_form            (risk: low)
+ * • composio_googlemeet_list_conference_records (risk: low)
  *
  * ============================================================================
  */
@@ -64,6 +77,12 @@ const JIRA_ACCOUNT_ID = process.env.JIRA_CONNECTED_ACCOUNT_ID || '';
 const DRIVE_ACCOUNT_ID = process.env.GOOGLEDRIVE_CONNECTED_ACCOUNT_ID || '';
 const CALENDAR_ACCOUNT_ID = process.env.GOOGLECALENDAR_CONNECTED_ACCOUNT_ID || '';
 const TEAMS_ACCOUNT_ID = process.env.MICROSOFT_TEAMS_CONNECTED_ACCOUNT_ID || '';
+const GMAIL_ACCOUNT_ID = process.env.GMAIL_CONNECTED_ACCOUNT_ID || '';
+const SHEETS_ACCOUNT_ID = process.env.GOOGLESHEETS_CONNECTED_ACCOUNT_ID || '';
+const DOCS_ACCOUNT_ID = process.env.GOOGLEDOCS_CONNECTED_ACCOUNT_ID || '';
+const FORMS_ACCOUNT_ID = process.env.GOOGLEFORMS_CONNECTED_ACCOUNT_ID || '';
+const FORMS_TEST_FORM_ID = process.env.GOOGLEFORMS_TEST_FORM_ID || '';
+const MEET_ACCOUNT_ID = process.env.GOOGLEMEET_CONNECTED_ACCOUNT_ID || '';
 
 function checkEnv(): void {
   const missing = [
@@ -144,6 +163,71 @@ async function main(): Promise<void> {
     printResult('composio_microsoft_teams_teams_list', teams);
   } else {
     console.info('\n⚠️  Skipping Microsoft Teams (MICROSOFT_TEAMS_CONNECTED_ACCOUNT_ID not set)');
+  }
+
+  // ── 5. Gmail: fetch the authenticated user's profile ──────────────────────
+  if (GMAIL_ACCOUNT_ID) {
+    console.info('\n─── Gmail ───────────────────────────────────────────────────────');
+    const profile = await matimo.execute('composio_gmail_get_profile', {
+      composio_user_id: COMPOSIO_USER_ID,
+      composio_connected_account_id: GMAIL_ACCOUNT_ID,
+    });
+    printResult('composio_gmail_get_profile', profile);
+  } else {
+    console.info('\n⚠️  Skipping Gmail (GMAIL_CONNECTED_ACCOUNT_ID not set)');
+  }
+
+  // ── 6. Google Sheets: search accessible spreadsheets ───────────────────────
+  if (SHEETS_ACCOUNT_ID) {
+    console.info('\n─── Google Sheets ───────────────────────────────────────────────');
+    const spreadsheets = await matimo.execute('composio_googlesheets_search_spreadsheets', {
+      composio_user_id: COMPOSIO_USER_ID,
+      composio_connected_account_id: SHEETS_ACCOUNT_ID,
+    });
+    printResult('composio_googlesheets_search_spreadsheets', spreadsheets);
+  } else {
+    console.info('\n⚠️  Skipping Google Sheets (GOOGLESHEETS_CONNECTED_ACCOUNT_ID not set)');
+  }
+
+  // ── 7. Google Docs: search accessible documents ────────────────────────────
+  if (DOCS_ACCOUNT_ID) {
+    console.info('\n─── Google Docs ─────────────────────────────────────────────────');
+    const documents = await matimo.execute('composio_googledocs_search_documents', {
+      composio_user_id: COMPOSIO_USER_ID,
+      composio_connected_account_id: DOCS_ACCOUNT_ID,
+    });
+    printResult('composio_googledocs_search_documents', documents);
+  } else {
+    console.info('\n⚠️  Skipping Google Docs (GOOGLEDOCS_CONNECTED_ACCOUNT_ID not set)');
+  }
+
+  // ── 8. Google Forms: fetch a known form by ID ───────────────────────────────
+  // The Forms API has no "list my forms" endpoint, so this one needs a form ID
+  // up front (unlike the other read-only calls above).
+  if (FORMS_ACCOUNT_ID && FORMS_TEST_FORM_ID) {
+    console.info('\n─── Google Forms ────────────────────────────────────────────────');
+    const form = await matimo.execute('composio_googleforms_get_form', {
+      composio_user_id: COMPOSIO_USER_ID,
+      composio_connected_account_id: FORMS_ACCOUNT_ID,
+      formId: FORMS_TEST_FORM_ID,
+    });
+    printResult('composio_googleforms_get_form', form);
+  } else {
+    console.info(
+      '\n⚠️  Skipping Google Forms (GOOGLEFORMS_CONNECTED_ACCOUNT_ID or GOOGLEFORMS_TEST_FORM_ID not set)'
+    );
+  }
+
+  // ── 9. Google Meet: list recent conference records ─────────────────────────
+  if (MEET_ACCOUNT_ID) {
+    console.info('\n─── Google Meet ─────────────────────────────────────────────────');
+    const records = await matimo.execute('composio_googlemeet_list_conference_records', {
+      composio_user_id: COMPOSIO_USER_ID,
+      composio_connected_account_id: MEET_ACCOUNT_ID,
+    });
+    printResult('composio_googlemeet_list_conference_records', records);
+  } else {
+    console.info('\n⚠️  Skipping Google Meet (GOOGLEMEET_CONNECTED_ACCOUNT_ID not set)');
   }
 
   console.info('\n' + '='.repeat(70));

--- a/typescript/examples/tools/composio/composio-langchain.ts
+++ b/typescript/examples/tools/composio/composio-langchain.ts
@@ -17,7 +17,7 @@
  * ✅ Users give high-level instructions, not specific API calls
  *
  * ⚠️  TOOL COUNT — LangChain has a hard limit of 128 tools per call.
- * @matimo/composio currently ships 342 tools across 9 toolkits. This
+ * @matimo/composio currently ships 449 tools across 14 toolkits. This
  * example filters to a curated subset before binding to the LLM. In
  * production, bind only the toolkits relevant to the agent's task.
  *
@@ -30,17 +30,19 @@
  *    JIRA_CONNECTED_ACCOUNT_ID=ca_...    (optional, enables Jira tasks)
  *    GOOGLEDRIVE_CONNECTED_ACCOUNT_ID=ca_...  (optional, enables Drive tasks)
  *    GOOGLECALENDAR_CONNECTED_ACCOUNT_ID=ca_... (optional, enables Calendar tasks)
+ *    GMAIL_CONNECTED_ACCOUNT_ID=ca_...   (optional, enables Gmail tasks)
  *
  * 2. Run:
  *    pnpm composio:langchain
  *
  * WHAT THE AGENT DOES:
  * ─────────────────────────────────────────────────────────────────────────
- * Given a task like "Find my unresolved Jira issues and check my upcoming
- * calendar events", the agent will:
+ * Given a task like "Find my unresolved Jira issues, check my upcoming
+ * calendar events, and summarize my unread Gmail", the agent will:
  *   1. Call composio_jira_search_issues with JQL for unresolved issues
  *   2. Call composio_googlecalendar_events_list for upcoming events
- *   3. Synthesise the results into a natural language response
+ *   3. Call composio_gmail_fetch_emails for unread messages
+ *   4. Synthesise the results into a natural language response
  *
  * ============================================================================
  */
@@ -59,6 +61,7 @@ const COMPOSIO_USER_ID = process.env.COMPOSIO_USER_ID || '';
 const JIRA_ACCOUNT_ID = process.env.JIRA_CONNECTED_ACCOUNT_ID || '';
 const DRIVE_ACCOUNT_ID = process.env.GOOGLEDRIVE_CONNECTED_ACCOUNT_ID || '';
 const CALENDAR_ACCOUNT_ID = process.env.GOOGLECALENDAR_CONNECTED_ACCOUNT_ID || '';
+const GMAIL_ACCOUNT_ID = process.env.GMAIL_CONNECTED_ACCOUNT_ID || '';
 
 async function main(): Promise<void> {
   if (!process.env.COMPOSIO_API_KEY || !COMPOSIO_USER_ID) {
@@ -88,11 +91,12 @@ async function main(): Promise<void> {
   if (JIRA_ACCOUNT_ID) ENABLED_TOOLKITS.add('jira');
   if (DRIVE_ACCOUNT_ID) ENABLED_TOOLKITS.add('googledrive');
   if (CALENDAR_ACCOUNT_ID) ENABLED_TOOLKITS.add('googlecalendar');
+  if (GMAIL_ACCOUNT_ID) ENABLED_TOOLKITS.add('gmail');
 
   if (ENABLED_TOOLKITS.size === 0) {
     console.error('\n❌ No connected accounts configured — set at least one of:');
     console.error('   JIRA_CONNECTED_ACCOUNT_ID, GOOGLEDRIVE_CONNECTED_ACCOUNT_ID,');
-    console.error('   GOOGLECALENDAR_CONNECTED_ACCOUNT_ID');
+    console.error('   GOOGLECALENDAR_CONNECTED_ACCOUNT_ID, GMAIL_CONNECTED_ACCOUNT_ID');
     process.exit(1);
   }
 
@@ -111,6 +115,7 @@ async function main(): Promise<void> {
     jira: JIRA_ACCOUNT_ID,
     googledrive: DRIVE_ACCOUNT_ID,
     googlecalendar: CALENDAR_ACCOUNT_ID,
+    gmail: GMAIL_ACCOUNT_ID,
   };
 
   // convertToolsToLangChain(tools, matimoInstance, envVarsToInject)
@@ -139,6 +144,7 @@ async function main(): Promise<void> {
     );
   if (CALENDAR_ACCOUNT_ID) taskParts.push('list upcoming Google Calendar events for today');
   if (DRIVE_ACCOUNT_ID) taskParts.push('list recent files in Google Drive');
+  if (GMAIL_ACCOUNT_ID) taskParts.push('fetch my 5 most recent Gmail messages');
   const task = `${userContext} Then: ${taskParts.join(', then ')}`;
 
   console.info(`\n🎯 Task: "${taskParts.join(', then ')}"`);

--- a/typescript/examples/tools/composio/composio-with-approval.ts
+++ b/typescript/examples/tools/composio/composio-with-approval.ts
@@ -28,13 +28,17 @@
  * • composio_jira_get_current_user (risk: low)  → executes immediately
  * • composio_jira_create_issue     (risk: medium) → pauses for approval
  * • composio_jira_delete_issue     (risk: high)   → pauses for approval
+ * • composio_gmail_get_profile     (risk: low)    → executes immediately
+ * • composio_gmail_send_email      (risk: medium) → pauses for approval
+ * • composio_gmail_delete_message  (risk: high)   → pauses for approval
  *
  * SETUP:
  * ─────────────────────────────────────────────────────────────────────────
  * 1. Set in .env:
  *    COMPOSIO_API_KEY=...
  *    COMPOSIO_USER_ID=...
- *    JIRA_CONNECTED_ACCOUNT_ID=ca_...
+ *    JIRA_CONNECTED_ACCOUNT_ID=ca_...   (optional, enables the Jira demo)
+ *    GMAIL_CONNECTED_ACCOUNT_ID=ca_...  (optional, enables the Gmail demo)
  *
  * 2. Run interactively (prompted for each write/delete):
  *    pnpm composio:approval
@@ -106,6 +110,10 @@ class ComposioRiskPolicyEngine implements PolicyEngine {
   canCreate(context: PolicyContext, tool: ToolDefinition): PolicyDecision {
     return this.base.canCreate(context, tool);
   }
+
+  filterForAgent(context: PolicyContext, tools: ToolDefinition[]): ToolDefinition[] {
+    return this.base.filterForAgent(context, tools);
+  }
 }
 
 function createApprovalCallback(): HITLCallback {
@@ -153,6 +161,8 @@ function createApprovalCallback(): HITLCallback {
 async function main(): Promise<void> {
   const userId = process.env.COMPOSIO_USER_ID || '';
   const jiraAccountId = process.env.JIRA_CONNECTED_ACCOUNT_ID || '';
+  const gmailAccountId = process.env.GMAIL_CONNECTED_ACCOUNT_ID || '';
+  const gmailTestRecipient = process.env.GMAIL_TEST_RECIPIENT_EMAIL || 'test@example.com';
 
   if (!process.env.COMPOSIO_API_KEY || !userId) {
     console.error('\n❌ COMPOSIO_API_KEY and COMPOSIO_USER_ID are required');
@@ -224,6 +234,63 @@ async function main(): Promise<void> {
     const msg = (err as Error).message;
     if (msg.includes('rejected') || msg.includes('denied')) {
       console.info('⛔ Tool execution rejected by approver — no issue deleted');
+    } else {
+      console.info('⚠️  Error:', msg);
+    }
+  }
+
+  // ── Gmail: same three-tier risk demo, different toolkit ────────────────────
+  if (!gmailAccountId) {
+    console.error(
+      '\n⚠️  GMAIL_CONNECTED_ACCOUNT_ID not set — using dummy values to demonstrate policy flow'
+    );
+  }
+
+  const gmailCreds = {
+    composio_user_id: userId,
+    composio_connected_account_id: gmailAccountId || 'ca_not_connected',
+  };
+
+  // ── 4. Low-risk tool: executes immediately, no prompt ─────────────────────
+  console.info('\n─── 4. Low-risk: composio_gmail_get_profile ──────────────────────');
+  try {
+    const result = await matimo.execute('composio_gmail_get_profile', gmailCreds);
+    console.info('✅ Result:', JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.info('⚠️  Error (expected if Gmail is not connected):', (err as Error).message);
+  }
+
+  // ── 5. Medium-risk tool: paused until approved ────────────────────────────
+  console.info('\n─── 5. Medium-risk: composio_gmail_send_email ────────────────────');
+  try {
+    const result = await matimo.execute('composio_gmail_send_email', {
+      ...gmailCreds,
+      recipient_email: gmailTestRecipient,
+      subject: 'Matimo composio HITL demo',
+      body: "Sent via composio_gmail_send_email through Matimo's HITL approval flow.",
+    });
+    console.info('✅ Result:', JSON.stringify(result, null, 2));
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg.includes('rejected') || msg.includes('denied')) {
+      console.info('⛔ Tool execution rejected by approver — no email sent');
+    } else {
+      console.info('⚠️  Error:', msg);
+    }
+  }
+
+  // ── 6. High-risk tool: paused until approved ──────────────────────────────
+  console.info('\n─── 6. High-risk: composio_gmail_delete_message ──────────────────');
+  try {
+    const result = await matimo.execute('composio_gmail_delete_message', {
+      ...gmailCreds,
+      message_id: 'test_message_id_placeholder',
+    });
+    console.info('✅ Result:', JSON.stringify(result, null, 2));
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg.includes('rejected') || msg.includes('denied')) {
+      console.info('⛔ Tool execution rejected by approver — no message deleted');
     } else {
       console.info('⚠️  Error:', msg);
     }

--- a/typescript/jest.config.cjs
+++ b/typescript/jest.config.cjs
@@ -37,6 +37,7 @@ module.exports = {
   setupFiles: ['<rootDir>/jest.setup.js'],
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', {
+      isolatedModules: true,
       tsconfig: {
         allowJs: true,
         esModuleInterop: true,

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matimo",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A framework-agnostic SDK with pre-built providers, a skills knowledge layer, MCP out of the box, and agents that autonomously build new capabilities — governed by a policy engine you control.",
   "main": "packages/core/dist/index.js",
   "types": "packages/core/dist/index.d.ts",

--- a/typescript/packages/bruno/package.json
+++ b/typescript/packages/bruno/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/bruno",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Bruno CLI tools for Matimo \u2014 API collection execution, import, and validation",
   "license": "MIT",
   "files": [

--- a/typescript/packages/bruno/package.json
+++ b/typescript/packages/bruno/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/bruno",
   "version": "0.1.6",
   "description": "Bruno CLI tools for Matimo \u2014 API collection execution, import, and validation",
+  "license": "MIT",
   "files": [
     "tools",
     "README.md",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/cli",
   "version": "0.1.6",
   "description": "CLI tools for managing Matimo tool installations",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/typescript/packages/cli/package.json
+++ b/typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "CLI tools for managing Matimo tool installations",
   "license": "MIT",
   "main": "dist/index.js",

--- a/typescript/packages/composio/README.md
+++ b/typescript/packages/composio/README.md
@@ -23,7 +23,7 @@ Wrapping Composio's catalog with Matimo's policy engine gets users governed
 access to broad integration coverage immediately. Over time, the highest-usage
 toolkits here (Google Workspace, Jira, Linear, Asana are the current
 candidates) are expected to graduate into first-party `@matimo/<provider>`
-packages with native auth, no proxy hop, and the full test/example suite —
+packages with native auth, no extra network hop, and the full test/example suite —
 at which point their `composio_*` equivalents can be deprecated in favor of
 the native ones. Until then, this package is the pragmatic way to give
 agents broad, governed tool access without gating it on our own build
@@ -32,7 +32,7 @@ velocity.
 ## 🔑 Bring Your Own Composio Key — and Non-Affiliation
 
 Every tool in this package requires **your own** `COMPOSIO_API_KEY` and your
-own Composio connected accounts, supplied at runtime — Matimo never holds a Composio account or credential of its own, and no request is proxied through any Matimo-operated infrastructure other than your own deployment. You are responsible for independently reading and complying with [Composio's Terms of Service](https://composio.dev/terms) and [Privacy Policy](https://composio.dev/privacy) before connecting an account.
+own Composio connected accounts, supplied at runtime — Matimo never holds a Composio account or credential of its own, and no request is routed through any Matimo-operated infrastructure other than your own deployment. You are responsible for independently reading and complying with [Composio's Terms of Service](https://composio.dev/terms) and [Privacy Policy](https://composio.dev/privacy) before connecting an account.
 This BYOK pattern mirrors how other platforms built on Composio's catalog
 work (e.g. [Langflow](https://docs.langflow.org/bundles-composio),
 [KiloClaw](https://kilo.ai/docs/kiloclaw/development-tools/composio)) 
@@ -41,7 +41,7 @@ work (e.g. [Langflow](https://docs.langflow.org/bundles-composio),
 "Composio" is used here solely to describe interoperability with their
 public API.
 
-Every tool in this package proxies a single Composio action via Composio's
+Every tool in this package calls a single Composio action via Composio's
 REST execute endpoint:
 
 ```

--- a/typescript/packages/composio/README.md
+++ b/typescript/packages/composio/README.md
@@ -5,6 +5,49 @@ from "agent has raw API access" into "agent has governed, auditable,
 human-approvable API access" — same breadth, with Matimo's policy engine,
 risk classification, and human-in-the-loop (HITL) approval layered on top.
 
+## 🙏 Credit Where It's Due
+
+The 449 tool definitions in this package exist because
+[Composio](https://composio.dev) already built, tested, and maintains OAuth
+and API coverage for Asana, Jira, Linear, Google Workspace, Microsoft 365,
+and dozens of other toolkits. Matimo's own tool-authoring bar is intentionally
+high — every native provider tool requires 100% unit coverage, four
+TypeScript examples, and three Python examples (see the root
+[CLAUDE.md](../../../CLAUDE.md#adding-a-new-tool--mandatory-workflow)).
+Hand-building and maintaining that for 449 actions across 14 toolkits, each
+with its own auth flow and API quirks, isn't a good use of engineering time
+when Composio has already solved it well.
+
+**This is a deliberate, temporary bridge, not the long-term architecture.**
+Wrapping Composio's catalog with Matimo's policy engine gets users governed
+access to broad integration coverage immediately. Over time, the highest-usage
+toolkits here (Google Workspace, Jira, Linear, Asana are the current
+candidates) are expected to graduate into first-party `@matimo/<provider>`
+packages with native auth, no proxy hop, and the full test/example suite —
+at which point their `composio_*` equivalents can be deprecated in favor of
+the native ones. Until then, this package is the pragmatic way to give
+agents broad, governed tool access without gating it on our own build
+velocity.
+
+## 🔑 Bring Your Own Composio Key — and Non-Affiliation
+
+Every tool in this package requires **your own** `COMPOSIO_API_KEY` and your
+own Composio connected accounts, supplied at runtime — Matimo never holds a
+Composio account or credential of its own, and no request is proxied through
+any Matimo-operated infrastructure other than your own deployment. You are
+responsible for independently reading and complying with
+[Composio's Terms of Service](https://composio.dev/terms) and
+[Privacy Policy](https://composio.dev/privacy) before connecting an account.
+This BYOK pattern mirrors how other platforms built on Composio's catalog
+work (e.g. [Langflow](https://docs.langflow.org/bundles-composio),
+[KiloClaw](https://kilo.ai/docs/kiloclaw/development-tools/composio)) — see
+[`docs/compliance/`](../../../docs/compliance/) for dated research on this,
+which is **not legal advice**.
+
+**Matimo is not affiliated with, endorsed by, or sponsored by Composio.**
+"Composio" is used here solely to describe interoperability with their
+public API.
+
 Every tool in this package proxies a single Composio action via Composio's
 REST execute endpoint:
 

--- a/typescript/packages/composio/README.md
+++ b/typescript/packages/composio/README.md
@@ -32,17 +32,10 @@ velocity.
 ## 🔑 Bring Your Own Composio Key — and Non-Affiliation
 
 Every tool in this package requires **your own** `COMPOSIO_API_KEY` and your
-own Composio connected accounts, supplied at runtime — Matimo never holds a
-Composio account or credential of its own, and no request is proxied through
-any Matimo-operated infrastructure other than your own deployment. You are
-responsible for independently reading and complying with
-[Composio's Terms of Service](https://composio.dev/terms) and
-[Privacy Policy](https://composio.dev/privacy) before connecting an account.
+own Composio connected accounts, supplied at runtime — Matimo never holds a Composio account or credential of its own, and no request is proxied through any Matimo-operated infrastructure other than your own deployment. You are responsible for independently reading and complying with [Composio's Terms of Service](https://composio.dev/terms) and [Privacy Policy](https://composio.dev/privacy) before connecting an account.
 This BYOK pattern mirrors how other platforms built on Composio's catalog
 work (e.g. [Langflow](https://docs.langflow.org/bundles-composio),
-[KiloClaw](https://kilo.ai/docs/kiloclaw/development-tools/composio)) — see
-[`docs/compliance/`](../../../docs/compliance/) for dated research on this,
-which is **not legal advice**.
+[KiloClaw](https://kilo.ai/docs/kiloclaw/development-tools/composio)) 
 
 **Matimo is not affiliated with, endorsed by, or sponsored by Composio.**
 "Composio" is used here solely to describe interoperability with their

--- a/typescript/packages/composio/package.json
+++ b/typescript/packages/composio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/composio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Governed access to Composio's tool catalog for Matimo — policy engine, risk classification, and HITL approval on top of Composio's 250+ integrations",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/composio/package.json
+++ b/typescript/packages/composio/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/composio",
   "version": "0.1.6",
   "description": "Governed access to Composio's tool catalog for Matimo — policy engine, risk classification, and HITL approval on top of Composio's 250+ integrations",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/composio/tools/composio_gmail_add_label_to_email/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_add_label_to_email/definition.yaml
@@ -1,0 +1,87 @@
+name: composio_gmail_add_label_to_email
+description: >-
+  Adds and/or removes specified gmail labels for a message; ensure `message id` and all `label ids`
+  are valid (use 'listlabels' for custom label ids).
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user.
+    default: me
+  message_id:
+    type: string
+    description: Immutable ID of the message to modify (e.g., from 'fetchEmails' or 'fetchMessagesByThreadId').
+    required: true
+  add_label_ids:
+    type: array
+    description: >-
+      Label IDs to add. For custom labels, obtain IDs via 'listLabels'. System labels (e.g.,
+      'INBOX', 'SPAM') can also be used.
+    default: []
+  remove_label_ids:
+    type: array
+    description: >-
+      Label IDs to remove. For custom labels, obtain IDs via 'listLabels'. System labels can also be
+      used.
+    default: []
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_ADD_LABEL_TO_EMAIL
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_add_label_to_email
+      user_id: '{user_id}'
+      message_id: '{message_id}'
+      add_label_ids: '{add_label_ids}'
+      remove_label_ids: '{remove_label_ids}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_ADD_LABEL_TO_EMAIL

--- a/typescript/packages/composio/tools/composio_gmail_create_email_draft/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_create_email_draft/definition.yaml
@@ -1,0 +1,113 @@
+name: composio_gmail_create_email_draft
+description: >-
+  Creates a gmail email draft, supporting to/cc/bcc, subject, plain/html body (ensure `is html=true`
+  for html), attachments, and threading.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  cc:
+    type: array
+    description: '''Cc'' (carbon copy) recipient email addresses.'
+    default: []
+  bcc:
+    type: array
+    description: '''Bcc'' (blind carbon copy) recipient email addresses.'
+    default: []
+  body:
+    type: string
+    description: Email body content (plain text or HTML); `is_html` must be True if HTML.
+    required: true
+  is_html:
+    type: boolean
+    description: Set to True if `body` is HTML, otherwise the action may fail.
+    default: false
+  subject:
+    type: string
+    description: Email subject line.
+    required: true
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user.
+    default: me
+  thread_id:
+    type: string
+    description: ID of an existing Gmail thread to reply to; omit for new thread.
+    default: null
+  attachment:
+    type: object
+    description: File to attach to the email.
+    default: null
+  recipient_email:
+    type: string
+    description: Primary recipient's email address.
+    required: true
+  extra_recipients:
+    type: array
+    description: Additional 'To' recipient email addresses.
+    default: []
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_CREATE_EMAIL_DRAFT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_create_email_draft
+      cc: '{cc}'
+      bcc: '{bcc}'
+      body: '{body}'
+      is_html: '{is_html}'
+      subject: '{subject}'
+      user_id: '{user_id}'
+      thread_id: '{thread_id}'
+      attachment: '{attachment}'
+      recipient_email: '{recipient_email}'
+      extra_recipients: '{extra_recipients}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_CREATE_EMAIL_DRAFT

--- a/typescript/packages/composio/tools/composio_gmail_create_label/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_create_label/definition.yaml
@@ -1,0 +1,94 @@
+name: composio_gmail_create_label
+description: Creates a new label with a unique name in the specified user's gmail account.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: The email address of the user in whose account the label will be created.
+    default: me
+  label_name:
+    type: string
+    description: >-
+      The name for the new label. Must be unique within the account, non-blank, maximum length 225
+      characters, cannot contain ',' or '/', not only whitespace, and must not be a reserved system
+      label (e.g., INBOX, DRAFTS, SENT).
+    required: true
+  text_color:
+    type: string
+    description: The text color of the label, in hex (e.g., "#000000").
+    default: null
+  background_color:
+    type: string
+    description: The background color of the label, in hex (e.g., "#FFFFFF").
+    default: null
+  label_list_visibility:
+    type: string
+    description: Controls how the label is displayed in the label list in the Gmail sidebar.
+    default: labelShow
+  message_list_visibility:
+    type: string
+    description: Controls how messages with this label are displayed in the message list.
+    default: show
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_CREATE_LABEL
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_create_label
+      user_id: '{user_id}'
+      label_name: '{label_name}'
+      text_color: '{text_color}'
+      background_color: '{background_color}'
+      label_list_visibility: '{label_list_visibility}'
+      message_list_visibility: '{message_list_visibility}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_CREATE_LABEL

--- a/typescript/packages/composio/tools/composio_gmail_delete_draft/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_delete_draft/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_gmail_delete_draft
+description: >-
+  Permanently deletes a specific gmail draft using its id; ensure the draft exists and the user has
+  necessary permissions for the given `user id`.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user; 'me' is recommended.
+    default: me
+  draft_id:
+    type: string
+    description: Immutable ID of the draft to delete, typically obtained when the draft was created.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_DELETE_DRAFT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_delete_draft
+      user_id: '{user_id}'
+      draft_id: '{draft_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_DELETE_DRAFT

--- a/typescript/packages/composio/tools/composio_gmail_delete_message/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_delete_message/definition.yaml
@@ -1,0 +1,74 @@
+name: composio_gmail_delete_message
+description: >-
+  Permanently deletes a specific email message by its id from a gmail mailbox; for `user id`, use
+  'me' for the authenticated user or an email address to which the authenticated user has delegated
+  access.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's email address. The special value 'me' refers to the authenticated user.
+    default: me
+  message_id:
+    type: string
+    description: Identifier of the email message to delete.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_DELETE_MESSAGE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_delete_message
+      user_id: '{user_id}'
+      message_id: '{message_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_DELETE_MESSAGE

--- a/typescript/packages/composio/tools/composio_gmail_fetch_emails/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_fetch_emails/definition.yaml
@@ -1,0 +1,123 @@
+name: composio_gmail_fetch_emails
+description: >-
+  Fetches a list of email messages from a gmail account, supporting filtering, pagination, and
+  optional full content retrieval.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  query:
+    type: string
+    description: >-
+      Gmail advanced search query (e.g., 'from:user subject:meeting'). Supports operators like
+      'from:', 'to:', 'subject:', 'label:', 'has:attachment', 'is:unread', 'after:YYYY/MM/DD',
+      'before:YYYY/MM/DD', AND/OR/NOT. Use quotes for exact phrases. Omit for no query filter.
+    default: null
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user.
+    default: me
+  verbose:
+    type: boolean
+    description: >-
+      If false, uses optimized concurrent metadata fetching for faster performance (~75%
+      improvement). If true, uses standard detailed message fetching. When false, only essential
+      fields (subject, sender, recipient, time, labels) are guaranteed.
+    default: true
+  ids_only:
+    type: boolean
+    description: >-
+      If true, only returns message IDs from the list API without fetching individual message
+      details. Fastest option for getting just message IDs and thread IDs.
+    default: false
+  label_ids:
+    type: array
+    description: >-
+      Filter by label IDs; only messages with all specified labels are returned. Common IDs:
+      'INBOX', 'SPAM', 'TRASH', 'UNREAD', 'STARRED', 'IMPORTANT', 'CATEGORY_PRIMARY' (alias
+      'CATEGORY_PERSONAL'), 'CATEGORY_SOCIAL', 'CATEGORY_PROMOTIONS', 'CATEGORY_UPDATES',
+      'CATEGORY_FORUMS'. Use 'listLabels' action for custom IDs.
+  page_token:
+    type: string
+    description: >-
+      Token for retrieving a specific page, obtained from a previous response's `nextPageToken`.
+      Omit for the first page.
+    default: null
+  max_results:
+    type: number
+    description: Maximum number of messages to retrieve per page.
+    default: 1
+  include_payload:
+    type: boolean
+    description: >-
+      Set to true to include full message payload (headers, body, attachments); false for metadata
+      only.
+    default: true
+  include_spam_trash:
+    type: boolean
+    description: Set to true to include messages from 'SPAM' and 'TRASH'.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_FETCH_EMAILS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_fetch_emails
+      query: '{query}'
+      user_id: '{user_id}'
+      verbose: '{verbose}'
+      ids_only: '{ids_only}'
+      label_ids: '{label_ids}'
+      page_token: '{page_token}'
+      max_results: '{max_results}'
+      include_payload: '{include_payload}'
+      include_spam_trash: '{include_spam_trash}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_FETCH_EMAILS

--- a/typescript/packages/composio/tools/composio_gmail_fetch_message_by_message_id/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_fetch_message_by_message_id/definition.yaml
@@ -1,0 +1,80 @@
+name: composio_gmail_fetch_message_by_message_id
+description: >-
+  Fetches a specific email message by its id, provided the `message id` exists and is accessible to
+  the authenticated `user id`.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  format:
+    type: string
+    description: >-
+      Format for message content: 'minimal' (ID/labels), 'full' (complete data), 'raw' (base64url
+      string), 'metadata' (ID/labels/headers).
+    default: full
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user.
+    default: me
+  message_id:
+    type: string
+    description: Unique ID of the email message to retrieve, obtainable from actions like 'List Messages'.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_fetch_message_by_message_id
+      format: '{format}'
+      user_id: '{user_id}'
+      message_id: '{message_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID

--- a/typescript/packages/composio/tools/composio_gmail_fetch_message_by_thread_id/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_fetch_message_by_thread_id/definition.yaml
@@ -1,0 +1,78 @@
+name: composio_gmail_fetch_message_by_thread_id
+description: >-
+  Retrieves messages from a gmail thread using its `thread id`, where the thread must be accessible
+  by the specified `user id`.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: The email address of the user.
+    default: me
+  thread_id:
+    type: string
+    description: Unique ID of the thread, obtainable from actions like 'listThreads' or 'fetchEmails'.
+    required: true
+  page_token:
+    type: string
+    description: Opaque page token for fetching a specific page of messages if results are paginated.
+    default: ''
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_FETCH_MESSAGE_BY_THREAD_ID
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_fetch_message_by_thread_id
+      user_id: '{user_id}'
+      thread_id: '{thread_id}'
+      page_token: '{page_token}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_FETCH_MESSAGE_BY_THREAD_ID

--- a/typescript/packages/composio/tools/composio_gmail_get_attachment/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_get_attachment/definition.yaml
@@ -1,0 +1,83 @@
+name: composio_gmail_get_attachment
+description: >-
+  Retrieves a specific attachment by id from a message in a user's gmail mailbox, requiring valid
+  message and attachment ids.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's email address ('me' for authenticated user).
+    default: me
+  file_name:
+    type: string
+    description: Desired filename for the downloaded attachment.
+    required: true
+  message_id:
+    type: string
+    description: Immutable ID of the message containing the attachment.
+    required: true
+  attachment_id:
+    type: string
+    description: ID of the attachment to retrieve.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_GET_ATTACHMENT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_get_attachment
+      user_id: '{user_id}'
+      file_name: '{file_name}'
+      message_id: '{message_id}'
+      attachment_id: '{attachment_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_GET_ATTACHMENT

--- a/typescript/packages/composio/tools/composio_gmail_get_contacts/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_get_contacts/definition.yaml
@@ -1,0 +1,88 @@
+name: composio_gmail_get_contacts
+description: >-
+  Fetches contacts (connections) for the authenticated google account, allowing selection of
+  specific data fields and pagination.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  page_token:
+    type: string
+    description: >-
+      Token to retrieve a specific page of results, obtained from 'nextPageToken' in a previous
+      response.
+  person_fields:
+    type: string
+    description: Comma-separated person fields to retrieve for each contact (e.g., 'names,emailAddresses').
+    default: emailAddresses,names,birthdays,genders
+  resource_name:
+    type: string
+    description: >-
+      Identifier for the person resource whose connections are listed; use 'people/me' for the
+      authenticated user.
+    default: people/me
+  include_other_contacts:
+    type: boolean
+    description: >-
+      Include 'Other Contacts' (interacted with but not explicitly saved) in addition to regular
+      contacts; if true, fetches from both endpoints and merges results.
+    default: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_GET_CONTACTS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_get_contacts
+      page_token: '{page_token}'
+      person_fields: '{person_fields}'
+      resource_name: '{resource_name}'
+      include_other_contacts: '{include_other_contacts}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_GET_CONTACTS

--- a/typescript/packages/composio/tools/composio_gmail_get_people/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_get_people/definition.yaml
@@ -1,0 +1,106 @@
+name: composio_gmail_get_people
+description: >-
+  Retrieves either a specific person's details (using `resource name`) or lists 'other contacts' (if
+  `other contacts` is true), with `person fields` specifying the data to return.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  page_size:
+    type: number
+    description: >-
+      The number of 'Other Contacts' to return per page. Applicable only when `other_contacts` is
+      true.
+    default: 10
+  page_token:
+    type: string
+    description: >-
+      An opaque token from a previous response to retrieve the next page of 'Other Contacts'
+      results. Applicable only when `other_contacts` is true and paginating.
+    default: ''
+  sync_token:
+    type: string
+    description: >-
+      A token from a previous 'Other Contacts' list call to retrieve only changes since the last
+      sync; leave empty for an initial full sync. Applicable only when `other_contacts` is true.
+    default: ''
+  person_fields:
+    type: string
+    description: >-
+      A comma-separated field mask to restrict which fields on the person (or persons) are returned.
+      Consult the Google People API documentation for a comprehensive list of valid fields.
+    default: emailAddresses,names,birthdays,genders
+  resource_name:
+    type: string
+    description: >-
+      Resource name identifying the person for whom to retrieve information (like the authenticated
+      user or a specific contact). Used only when `other_contacts` is false.
+    default: people/me
+  other_contacts:
+    type: boolean
+    description: >-
+      If true, retrieves 'Other Contacts' (people interacted with but not explicitly saved),
+      ignoring `resource_name` and enabling pagination/sync. If false, retrieves information for the
+      single person specified by `resource_name`.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_GET_PEOPLE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_get_people
+      page_size: '{page_size}'
+      page_token: '{page_token}'
+      sync_token: '{sync_token}'
+      person_fields: '{person_fields}'
+      resource_name: '{resource_name}'
+      other_contacts: '{other_contacts}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_GET_PEOPLE

--- a/typescript/packages/composio/tools/composio_gmail_get_profile/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_get_profile/definition.yaml
@@ -1,0 +1,70 @@
+name: composio_gmail_get_profile
+description: >-
+  Retrieves key gmail profile information (email address, message/thread totals, history id) for a
+  user.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: >-
+      The email address of the Gmail user whose profile is to be retrieved, or the special value
+      'me' to indicate the currently authenticated user.
+    default: me
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_GET_PROFILE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_get_profile
+      user_id: '{user_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_GET_PROFILE

--- a/typescript/packages/composio/tools/composio_gmail_list_drafts/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_list_drafts/definition.yaml
@@ -1,0 +1,85 @@
+name: composio_gmail_list_drafts
+description: >-
+  Retrieves a paginated list of email drafts from a user's gmail account. use verbose=true to get
+  full draft details including subject, body, sender, and timestamp.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's mailbox ID; use 'me' for the authenticated user.
+    default: me
+  verbose:
+    type: boolean
+    description: >-
+      If true, fetches full draft details including subject, sender, recipient, body, and timestamp.
+      If false, returns only draft IDs (faster).
+    default: false
+  page_token:
+    type: string
+    description: Token from a previous response to retrieve a specific page of drafts.
+    default: ''
+  max_results:
+    type: number
+    description: Maximum number of drafts to return per page.
+    default: 1
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_LIST_DRAFTS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_list_drafts
+      user_id: '{user_id}'
+      verbose: '{verbose}'
+      page_token: '{page_token}'
+      max_results: '{max_results}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_LIST_DRAFTS

--- a/typescript/packages/composio/tools/composio_gmail_list_labels/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_list_labels/definition.yaml
@@ -1,0 +1,68 @@
+name: composio_gmail_list_labels
+description: Retrieves a list of all system and user-created labels for the specified gmail account.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: >-
+      Identifies the Gmail account (owner's email or 'me' for authenticated user) for which labels
+      will be listed.
+    default: me
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_LIST_LABELS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_list_labels
+      user_id: '{user_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_LIST_LABELS

--- a/typescript/packages/composio/tools/composio_gmail_list_threads/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_list_threads/definition.yaml
@@ -1,0 +1,93 @@
+name: composio_gmail_list_threads
+description: >-
+  Retrieves a list of email threads from a gmail account, identified by `user id` (email address or
+  'me'), supporting filtering and pagination.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  query:
+    type: string
+    description: Filter for threads, using Gmail search query syntax (e.g., 'from:user@example.com is:unread').
+    default: ''
+  user_id:
+    type: string
+    description: The user's email address or 'me' to specify the authenticated Gmail account.
+    default: me
+  verbose:
+    type: boolean
+    description: >-
+      If false, returns threads with basic fields (id, snippet, historyId). If true, returns threads
+      with complete message details including headers, body, attachments, and metadata for each
+      message in the thread.
+    default: false
+  page_token:
+    type: string
+    description: >-
+      Token from a previous response to retrieve a specific page of results; omit for the first
+      page.
+    default: ''
+  max_results:
+    type: number
+    description: Maximum number of threads to return.
+    default: 10
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_LIST_THREADS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_list_threads
+      query: '{query}'
+      user_id: '{user_id}'
+      verbose: '{verbose}'
+      page_token: '{page_token}'
+      max_results: '{max_results}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_LIST_THREADS

--- a/typescript/packages/composio/tools/composio_gmail_modify_thread_labels/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_modify_thread_labels/definition.yaml
@@ -1,0 +1,83 @@
+name: composio_gmail_modify_thread_labels
+description: >-
+  Adds or removes specified existing label ids from a gmail thread, affecting all its messages;
+  ensure the thread id is valid.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user.
+    default: me
+  thread_id:
+    type: string
+    description: Immutable ID of the thread to modify.
+    required: true
+  add_label_ids:
+    type: array
+    description: List of label IDs to add to the thread; these labels must exist.
+    default: null
+  remove_label_ids:
+    type: array
+    description: List of label IDs to remove from the thread; these labels must exist.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_MODIFY_THREAD_LABELS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_modify_thread_labels
+      user_id: '{user_id}'
+      thread_id: '{thread_id}'
+      add_label_ids: '{add_label_ids}'
+      remove_label_ids: '{remove_label_ids}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_MODIFY_THREAD_LABELS

--- a/typescript/packages/composio/tools/composio_gmail_move_to_trash/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_move_to_trash/definition.yaml
@@ -1,0 +1,71 @@
+name: composio_gmail_move_to_trash
+description: Moves an existing, non-deleted email message to the trash for the specified user.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user.
+    default: me
+  message_id:
+    type: string
+    description: Identifier of the email message to move to trash.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_MOVE_TO_TRASH
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_move_to_trash
+      user_id: '{user_id}'
+      message_id: '{message_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_MOVE_TO_TRASH

--- a/typescript/packages/composio/tools/composio_gmail_patch_label/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_patch_label/definition.yaml
@@ -1,0 +1,95 @@
+name: composio_gmail_patch_label
+description: Patches the specified label.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  id:
+    type: string
+    description: The ID of the label to update.
+    required: true
+  name:
+    type: string
+    description: The display name of the label.
+    default: null
+  color:
+    type: object
+    description: >-
+      The color to assign to the label. Color is only available for labels that have their `type`
+      set to `user`.
+    default: null
+  userId:
+    type: string
+    description: >-
+      The user's email address. The special value `me` can be used to indicate the authenticated
+      user.
+    required: true
+  labelListVisibility:
+    type: string
+    description: The visibility of the label in the label list in the Gmail web interface.
+    default: null
+  messageListVisibility:
+    type: string
+    description: The visibility of messages with this label in the message list in the Gmail web interface.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_PATCH_LABEL
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_patch_label
+      id: '{id}'
+      name: '{name}'
+      color: '{color}'
+      userId: '{userId}'
+      labelListVisibility: '{labelListVisibility}'
+      messageListVisibility: '{messageListVisibility}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_PATCH_LABEL

--- a/typescript/packages/composio/tools/composio_gmail_remove_label/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_remove_label/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_gmail_remove_label
+description: >-
+  Permanently deletes a specific, existing user-created gmail label by its id for a user; cannot
+  delete system labels.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: User's email address or 'me' for the authenticated user.
+    default: me
+  label_id:
+    type: string
+    description: ID of the user-created label to be permanently deleted; must exist and not be a system label.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_REMOVE_LABEL
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_remove_label
+      user_id: '{user_id}'
+      label_id: '{label_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_REMOVE_LABEL

--- a/typescript/packages/composio/tools/composio_gmail_reply_to_thread/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_reply_to_thread/definition.yaml
@@ -1,0 +1,111 @@
+name: composio_gmail_reply_to_thread
+description: >-
+  Sends a reply within a specific gmail thread using the original thread's subject, requiring a
+  valid `thread id` and correctly formatted email addresses. supports attachments via the
+  `attachment` parameter with valid `s3key`, `mimetype`, and `name`.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  cc:
+    type: array
+    description: CC recipients' email addresses.
+    default: []
+  bcc:
+    type: array
+    description: BCC recipients' email addresses (hidden from other recipients).
+    default: []
+  is_html:
+    type: boolean
+    description: >-
+      Indicates if `message_body` is HTML; if True, body must be valid HTML, if False, body should
+      not contain HTML tags.
+    default: false
+  user_id:
+    type: string
+    description: Identifier for the user sending the reply; 'me' refers to the authenticated user.
+    default: me
+  thread_id:
+    type: string
+    description: Identifier of the Gmail thread for the reply.
+    required: true
+  attachment:
+    type: object
+    description: File to attach to the reply. Just Provide file path here
+    default: null
+  message_body:
+    type: string
+    description: Content of the reply message, either plain text or HTML.
+    required: true
+  recipient_email:
+    type: string
+    description: Primary recipient's email address.
+    required: true
+  extra_recipients:
+    type: array
+    description: Additional 'To' recipients' email addresses.
+    default: []
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_REPLY_TO_THREAD
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_reply_to_thread
+      cc: '{cc}'
+      bcc: '{bcc}'
+      is_html: '{is_html}'
+      user_id: '{user_id}'
+      thread_id: '{thread_id}'
+      attachment: '{attachment}'
+      message_body: '{message_body}'
+      recipient_email: '{recipient_email}'
+      extra_recipients: '{extra_recipients}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_REPLY_TO_THREAD

--- a/typescript/packages/composio/tools/composio_gmail_search_people/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_search_people/definition.yaml
@@ -1,0 +1,87 @@
+name: composio_gmail_search_people
+description: >-
+  Searches contacts by matching the query against names, nicknames, emails, phone numbers, and
+  organizations, optionally including 'other contacts'.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  query:
+    type: string
+    description: Matches contact names, nicknames, email addresses, phone numbers, and organization fields.
+    required: true
+  pageSize:
+    type: number
+    description: Maximum results to return; values >30 are capped to 30 by the API.
+    default: 10
+  person_fields:
+    type: string
+    description: >-
+      Comma-separated fields to return (e.g., 'names,emailAddresses'); see PersonFields enum. If
+      'other_contacts' is true, only 'emailAddresses', 'names', 'phoneNumbers' are allowed.
+    default: emailAddresses,names,phoneNumbers
+  other_contacts:
+    type: boolean
+    description: >-
+      Include 'Other Contacts' (interacted with but not explicitly saved) in search results; if
+      false, searches only primary contacts.
+    default: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_SEARCH_PEOPLE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_search_people
+      query: '{query}'
+      pageSize: '{pageSize}'
+      person_fields: '{person_fields}'
+      other_contacts: '{other_contacts}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_SEARCH_PEOPLE

--- a/typescript/packages/composio/tools/composio_gmail_send_draft/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_send_draft/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_gmail_send_draft
+description: Sends the specified, existing draft to the recipients in the to, cc, and bcc headers.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  user_id:
+    type: string
+    description: >-
+      The user's email address. The special value `me` can be used to indicate the authenticated
+      user.
+    default: me
+  draft_id:
+    type: string
+    description: The ID of the draft to send.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_SEND_DRAFT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_send_draft
+      user_id: '{user_id}'
+      draft_id: '{draft_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_SEND_DRAFT

--- a/typescript/packages/composio/tools/composio_gmail_send_email/definition.yaml
+++ b/typescript/packages/composio/tools/composio_gmail_send_email/definition.yaml
@@ -1,0 +1,109 @@
+name: composio_gmail_send_email
+description: >-
+  Sends an email via gmail api using the authenticated user's google profile display name, requiring
+  `is html=true` if the body contains html and valid `s3key`, `mimetype`, `name` for any attachment.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GMAIL toolkit, scoped to the calling tenant. The
+      "Connect GMAIL" flow must be completed before this tool will succeed.
+    required: true
+  cc:
+    type: array
+    description: Carbon Copy (CC) recipients' email addresses.
+    default: []
+  bcc:
+    type: array
+    description: Blind Carbon Copy (BCC) recipients' email addresses.
+    default: []
+  body:
+    type: string
+    description: Email content (plain text or HTML); if HTML, `is_html` must be `True`.
+    required: true
+  is_html:
+    type: boolean
+    description: Set to `True` if the email body contains HTML tags.
+    default: false
+  subject:
+    type: string
+    description: Subject line of the email.
+    default: null
+  user_id:
+    type: string
+    description: User's email address; the literal 'me' refers to the authenticated user.
+    default: me
+  attachment:
+    type: object
+    description: >-
+      File to attach; ensure `s3key`, `mimetype`, and `name` are set if provided. Omit or set to
+      null for no attachment.
+  recipient_email:
+    type: string
+    description: Primary recipient's email address.
+    required: true
+  extra_recipients:
+    type: array
+    description: Additional 'To' recipients' email addresses (not Cc or Bcc).
+    default: []
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GMAIL_SEND_EMAIL
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_gmail_send_email
+      cc: '{cc}'
+      bcc: '{bcc}'
+      body: '{body}'
+      is_html: '{is_html}'
+      subject: '{subject}'
+      user_id: '{user_id}'
+      attachment: '{attachment}'
+      recipient_email: '{recipient_email}'
+      extra_recipients: '{extra_recipients}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - gmail
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: gmail
+  composio_slug: GMAIL_SEND_EMAIL

--- a/typescript/packages/composio/tools/composio_googledocs_copy_document/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_copy_document/definition.yaml
@@ -1,0 +1,77 @@
+name: composio_googledocs_copy_document
+description: >-
+  Tool to create a copy of an existing google document. use this to duplicate a document, for
+  example, when using an existing document as a template. the copied document will have a default
+  title (e.g., 'copy of [original title]') if no new title is provided, and will be placed in the
+  user's root google drive folder.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  title:
+    type: string
+    description: >-
+      The title for the new copied document. If not provided, the title will be 'Copy of [original
+      document's title]'.
+    default: null
+  document_id:
+    type: string
+    description: The ID of the Google Document to be copied.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_COPY_DOCUMENT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_copy_document
+      title: '{title}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_COPY_DOCUMENT

--- a/typescript/packages/composio/tools/composio_googledocs_create_document/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_create_document/definition.yaml
@@ -1,0 +1,74 @@
+name: composio_googledocs_create_document
+description: >-
+  Creates a new google docs document using the provided title as filename and inserts the initial
+  text at the beginning if non-empty, returning the document's id and metadata (excluding body
+  content).
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  text:
+    type: string
+    description: Initial text content to insert at the beginning of the new document.
+    required: true
+  title:
+    type: string
+    description: Title for the new document, used as its filename in Google Drive.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_CREATE_DOCUMENT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_create_document
+      text: '{text}'
+      title: '{title}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_CREATE_DOCUMENT

--- a/typescript/packages/composio/tools/composio_googledocs_create_document_markdown/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_create_document_markdown/definition.yaml
@@ -1,0 +1,77 @@
+name: composio_googledocs_create_document_markdown
+description: >-
+  Creates a new google docs document, optionally initializing it with a title and content provided
+  as markdown text.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  title:
+    type: string
+    description: The title for the new Google Docs document.
+    required: true
+  markdown_text:
+    type: string
+    description: >-
+      The initial content for the document, formatted as Markdown. Supports various Markdown
+      elements including headings, lists (nested lists are not supported), tables, images (via
+      publicly accessible URLs), blockquotes, code blocks, and text formatting (bold, italic, etc.).
+      If an empty string is provided, the document will be created with only the title.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_CREATE_DOCUMENT_MARKDOWN
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_create_document_markdown
+      title: '{title}'
+      markdown_text: '{markdown_text}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_CREATE_DOCUMENT_MARKDOWN

--- a/typescript/packages/composio/tools/composio_googledocs_create_footer/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_create_footer/definition.yaml
@@ -1,0 +1,84 @@
+name: composio_googledocs_create_footer
+description: >-
+  Tool to create a new footer in a google document. use when you need to add a footer, optionally
+  specifying its type and the section it applies to.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  type:
+    type: string
+    description: The type of footer to create.
+    required: true
+    enum:
+      - HEADER_FOOTER_TYPE_UNSPECIFIED
+      - DEFAULT
+  document_id:
+    type: string
+    description: The ID of the document to create the footer in.
+    required: true
+  section_break_location:
+    type: object
+    description: >-
+      The location of the SectionBreak immediately preceding the section whose SectionStyle this
+      footer should belong to. If this is unset or refers to the first section break in the
+      document, the footer applies to the document style.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_CREATE_FOOTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_create_footer
+      type: '{type}'
+      document_id: '{document_id}'
+      section_break_location: '{section_break_location}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_CREATE_FOOTER

--- a/typescript/packages/composio/tools/composio_googledocs_create_footnote/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_create_footnote/definition.yaml
@@ -1,0 +1,82 @@
+name: composio_googledocs_create_footnote
+description: >-
+  Tool to create a new footnote in a google document. use this when you need to add a footnote at a
+  specific location or at the end of the document body.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  location:
+    type: object
+    description: >-
+      Inserts the footnote reference at a specific index in the document. The segmentId within this
+      Location object must be empty as footnotes can only be inserted in the document body.
+    default: null
+  documentId:
+    type: string
+    description: The ID of the document to create the footnote in.
+    required: true
+  endOfSegmentLocation:
+    type: object
+    description: >-
+      Inserts the footnote reference at the end of the document body. The segmentId within this
+      EndOfSegmentLocation object must be empty.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_CREATE_FOOTNOTE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_create_footnote
+      location: '{location}'
+      documentId: '{documentId}'
+      endOfSegmentLocation: '{endOfSegmentLocation}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_CREATE_FOOTNOTE

--- a/typescript/packages/composio/tools/composio_googledocs_create_header/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_create_header/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_create_header
+description: >-
+  Tool to create a new header in a google document. use this tool when you need to add a header to a
+  document, optionally specifying the section it applies to.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  documentId:
+    type: string
+    description: The ID of the document to create the header in.
+    required: true
+  createHeader:
+    type: object
+    description: The details of the header to create.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_CREATE_HEADER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_create_header
+      documentId: '{documentId}'
+      createHeader: '{createHeader}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_CREATE_HEADER

--- a/typescript/packages/composio/tools/composio_googledocs_create_named_range/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_create_named_range/definition.yaml
@@ -1,0 +1,88 @@
+name: composio_googledocs_create_named_range
+description: >-
+  Tool to create a new named range in a google document. use this to assign a name to a specific
+  part of the document for easier reference or programmatic manipulation.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  name:
+    type: string
+    description: The name for the new named range. Must be 1-256 characters.
+    required: true
+  documentId:
+    type: string
+    description: The ID of the document where the named range will be created.
+    required: true
+  rangeEndIndex:
+    type: number
+    description: The zero-based end index of the range.
+    required: true
+  rangeSegmentId:
+    type: string
+    description: Optional. The ID of the header, footer, or footnote. Empty for document body.
+    default: null
+  rangeStartIndex:
+    type: number
+    description: The zero-based start index of the range.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_CREATE_NAMED_RANGE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_create_named_range
+      name: '{name}'
+      documentId: '{documentId}'
+      rangeEndIndex: '{rangeEndIndex}'
+      rangeSegmentId: '{rangeSegmentId}'
+      rangeStartIndex: '{rangeStartIndex}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_CREATE_NAMED_RANGE

--- a/typescript/packages/composio/tools/composio_googledocs_create_paragraph_bullets/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_create_paragraph_bullets/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_create_paragraph_bullets
+description: >-
+  Tool to add bullets to paragraphs within a specified range in a google document. use when you need
+  to format a list or a set of paragraphs as bullet points.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document to update.
+    required: true
+  createParagraphBullets:
+    type: object
+    description: The createParagraphBullets parameter.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_CREATE_PARAGRAPH_BULLETS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_create_paragraph_bullets
+      document_id: '{document_id}'
+      createParagraphBullets: '{createParagraphBullets}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_CREATE_PARAGRAPH_BULLETS

--- a/typescript/packages/composio/tools/composio_googledocs_delete_content_range/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_content_range/definition.yaml
@@ -1,0 +1,78 @@
+name: composio_googledocs_delete_content_range
+description: >-
+  Tool to delete a range of content from a google document. use when you need to remove a specific
+  portion of text or other structural elements within a document.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  range:
+    type: object
+    description: >-
+      The range of content to delete. Deleting text across paragraph boundaries may merge paragraphs
+      and affect styles. Certain deletions can invalidate document structure (e.g., part of a
+      surrogate pair, last newline of critical elements, incomplete deletion of tables/equations).
+    required: true
+  document_id:
+    type: string
+    description: >-
+      The ID of the document from which to delete content. This ID can be found in the URL of the
+      Google Doc.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_CONTENT_RANGE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_content_range
+      range: '{range}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_CONTENT_RANGE

--- a/typescript/packages/composio/tools/composio_googledocs_delete_footer/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_footer/definition.yaml
@@ -1,0 +1,84 @@
+name: composio_googledocs_delete_footer
+description: >-
+  Tool to delete a footer from a google document. use when you need to remove a footer from a
+  specific section or the default footer.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  tab_id:
+    type: string
+    description: >-
+      The tab that contains the footer to delete. When omitted, the request is applied to the first
+      tab.
+    default: null
+  footer_id:
+    type: string
+    description: >-
+      The ID of the footer to delete. If this footer is defined on DocumentStyle, the reference to
+      this footer is removed, resulting in no footer of that type for the first section of the
+      document. If this footer is defined on a SectionStyle, the reference to this footer is removed
+      and the footer of that type is now continued from the previous section.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document to delete the footer from.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_FOOTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_footer
+      tab_id: '{tab_id}'
+      footer_id: '{footer_id}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_FOOTER

--- a/typescript/packages/composio/tools/composio_googledocs_delete_header/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_header/definition.yaml
@@ -1,0 +1,84 @@
+name: composio_googledocs_delete_header
+description: >-
+  Deletes the header from the specified section or the default header if no section is specified.
+  use this tool to remove a header from a google document.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  tab_id:
+    type: string
+    description: >-
+      The tab containing the header to delete. When omitted, the request is applied to the first
+      tab.
+    default: null
+  header_id:
+    type: string
+    description: >-
+      The ID of the header to delete. If this header is defined on `DocumentStyle`, the reference to
+      this header is removed, resulting in no header of that type for the first section of the
+      document. If this header is defined on a `SectionStyle`, the reference to this header is
+      removed and the header of that type is now continued from the previous section.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document from which to delete the header.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_HEADER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_header
+      tab_id: '{tab_id}'
+      header_id: '{header_id}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_HEADER

--- a/typescript/packages/composio/tools/composio_googledocs_delete_named_range/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_named_range/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_delete_named_range
+description: >-
+  Tool to delete a named range from a google document. use when you need to remove a previously
+  defined named range by its id or name.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document.
+    required: true
+  deleteNamedRange:
+    type: object
+    description: Specifies the named range to delete.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_NAMED_RANGE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_named_range
+      document_id: '{document_id}'
+      deleteNamedRange: '{deleteNamedRange}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_NAMED_RANGE

--- a/typescript/packages/composio/tools/composio_googledocs_delete_paragraph_bullets/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_paragraph_bullets/definition.yaml
@@ -1,0 +1,83 @@
+name: composio_googledocs_delete_paragraph_bullets
+description: >-
+  Tool to remove bullets from paragraphs within a specified range in a google document. use when you
+  need to clear bullet formatting from a section of a document.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  range:
+    type: object
+    description: >-
+      The range of the document from which to delete paragraph bullets. The range is applied to the
+      document body by default. To specify a different segment (e.g. header, footer), include
+      segment_id in the range object.
+    required: true
+  tab_id:
+    type: string
+    description: >-
+      The ID of the tab the range is in. If omitted, it applies to the first tab or the singular tab
+      in a single-tab document.
+    default: null
+  document_id:
+    type: string
+    description: The ID of the document to update.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_PARAGRAPH_BULLETS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_paragraph_bullets
+      range: '{range}'
+      tab_id: '{tab_id}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_PARAGRAPH_BULLETS

--- a/typescript/packages/composio/tools/composio_googledocs_delete_table/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_table/definition.yaml
@@ -1,0 +1,93 @@
+name: composio_googledocs_delete_table
+description: >-
+  Tool to delete an entire table from a google document. use when you have the document id and the
+  specific start and end index of the table element to be removed. the table's range can be found by
+  inspecting the document's content structure.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  tab_id:
+    type: string
+    description: >-
+      The ID of the tab containing the table, if the document uses tabs. If omitted, the action
+      applies to the first tab or the only tab.
+    default: null
+  segment_id:
+    type: string
+    description: >-
+      The ID of the segment (e.g., header, footer) containing the table. If omitted or empty, the
+      table is assumed to be in the main document body.
+    default: null
+  document_id:
+    type: string
+    description: The ID of the Google Document from which the table will be deleted.
+    required: true
+  table_end_index:
+    type: number
+    description: The end index (UTF-16 code unit) of the table's range to be deleted.
+    required: true
+  table_start_index:
+    type: number
+    description: The start index (UTF-16 code unit) of the table's range to be deleted.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_TABLE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_table
+      tab_id: '{tab_id}'
+      segment_id: '{segment_id}'
+      document_id: '{document_id}'
+      table_end_index: '{table_end_index}'
+      table_start_index: '{table_start_index}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_TABLE

--- a/typescript/packages/composio/tools/composio_googledocs_delete_table_column/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_table_column/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_delete_table_column
+description: >-
+  Tool to delete a column from a table in a google document. use this tool when you need to remove a
+  specific column from an existing table within a document.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  requests:
+    type: array
+    description: A list of requests to be applied to the document.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document to delete the table column from.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_TABLE_COLUMN
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_table_column
+      requests: '{requests}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_TABLE_COLUMN

--- a/typescript/packages/composio/tools/composio_googledocs_delete_table_row/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_delete_table_row/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_delete_table_row
+description: >-
+  Tool to delete a row from a table in a google document. use when you need to remove a specific row
+  from an existing table.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  documentId:
+    type: string
+    description: The ID of the document.
+    required: true
+  tableCellLocation:
+    type: object
+    description: The reference table cell location from which the row will be deleted.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_DELETE_TABLE_ROW
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_delete_table_row
+      documentId: '{documentId}'
+      tableCellLocation: '{tableCellLocation}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_DELETE_TABLE_ROW

--- a/typescript/packages/composio/tools/composio_googledocs_get_charts_from_spreadsheet/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_get_charts_from_spreadsheet/definition.yaml
@@ -1,0 +1,69 @@
+name: composio_googledocs_get_charts_from_spreadsheet
+description: >-
+  Tool to retrieve a list of all charts from a specified google sheets spreadsheet. use when you
+  need to get chart ids and their specifications for embedding or referencing elsewhere, such as in
+  google docs.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The ID of the Google Sheets spreadsheet from which to retrieve charts.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_GET_CHARTS_FROM_SPREADSHEET
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_get_charts_from_spreadsheet
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_GET_CHARTS_FROM_SPREADSHEET

--- a/typescript/packages/composio/tools/composio_googledocs_get_document_by_id/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_get_document_by_id/definition.yaml
@@ -1,0 +1,68 @@
+name: composio_googledocs_get_document_by_id
+description: Retrieves an existing google document by its id; will error if the document is not found.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  id:
+    type: string
+    description: >-
+      The unique identifier for the Google Document to be retrieved. This action specifically
+      fetches an existing document and will not create a new one if the ID is not found.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_GET_DOCUMENT_BY_ID
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_get_document_by_id
+      id: '{id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_GET_DOCUMENT_BY_ID

--- a/typescript/packages/composio/tools/composio_googledocs_insert_inline_image/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_insert_inline_image/definition.yaml
@@ -1,0 +1,85 @@
+name: composio_googledocs_insert_inline_image
+description: >-
+  Tool to insert an image from a given uri at a specified location in a google document as an inline
+  image. use when you need to add an image to a document programmatically.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  uri:
+    type: string
+    description: >-
+      The URI of the image. Images must be less than 50MB, not exceed 25 megapixels, and be in PNG,
+      JPEG, or GIF format. The URI can be at most 2 kB.
+    required: true
+  location:
+    type: object
+    description: The location in the document to insert the image.
+    required: true
+  documentId:
+    type: string
+    description: The ID of the document to update.
+    required: true
+  objectSize:
+    type: object
+    description: The size of the image. If not specified, the image is rendered at its intrinsic size.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_INSERT_INLINE_IMAGE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_insert_inline_image
+      uri: '{uri}'
+      location: '{location}'
+      documentId: '{documentId}'
+      objectSize: '{objectSize}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_INSERT_INLINE_IMAGE

--- a/typescript/packages/composio/tools/composio_googledocs_insert_page_break/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_insert_page_break/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_insert_page_break
+description: >-
+  Tool to insert a page break into a google document. use when you need to start new content on a
+  fresh page, such as at the end of a chapter or section.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  documentId:
+    type: string
+    description: The ID of the document to update.
+    required: true
+  insertPageBreak:
+    type: object
+    description: The details for the insertPageBreak request.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_INSERT_PAGE_BREAK
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_insert_page_break
+      documentId: '{documentId}'
+      insertPageBreak: '{insertPageBreak}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_INSERT_PAGE_BREAK

--- a/typescript/packages/composio/tools/composio_googledocs_insert_table_action/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_insert_table_action/definition.yaml
@@ -1,0 +1,106 @@
+name: composio_googledocs_insert_table_action
+description: >-
+  Tool to insert a table into a google document. use when you need to add a new table at a specific
+  location or at the end of a segment (like document body, header, or footer) in a document.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  rows:
+    type: number
+    description: The number of rows in the table.
+    required: true
+  index:
+    type: number
+    description: >-
+      The zero-based index where the table will be inserted. If provided, 'location' will be used.
+      If omitted and 'insertAtEndOfSegment' is false or omitted, 'endOfSegmentLocation' will be used
+      for the document body.
+    default: null
+  tabId:
+    type: string
+    description: The tab that the location is in. When omitted, the request is applied to the first tab.
+    default: null
+  columns:
+    type: number
+    description: The number of columns in the table.
+    required: true
+  segmentId:
+    type: string
+    description: >-
+      The ID of the header, footer or footnote the location is in. An empty segment ID signifies the
+      document's body.
+    default: null
+  documentId:
+    type: string
+    description: The ID of the document to update.
+    required: true
+  insertAtEndOfSegment:
+    type: boolean
+    description: >-
+      If true, inserts the table at the end of the segment (document body, header, or footer
+      specified by segment_id). If false or omitted, and 'index' is not provided, it defaults to
+      inserting at the end of the document body. If 'index' is provided, this field is ignored.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_INSERT_TABLE_ACTION
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_insert_table_action
+      rows: '{rows}'
+      index: '{index}'
+      tabId: '{tabId}'
+      columns: '{columns}'
+      segmentId: '{segmentId}'
+      documentId: '{documentId}'
+      insertAtEndOfSegment: '{insertAtEndOfSegment}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_INSERT_TABLE_ACTION

--- a/typescript/packages/composio/tools/composio_googledocs_insert_table_column/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_insert_table_column/definition.yaml
@@ -1,0 +1,75 @@
+name: composio_googledocs_insert_table_column
+description: >-
+  Tool to insert a new column into a table in a google document. use this tool when you need to add
+  a column to an existing table at a specific location.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  requests:
+    type: array
+    description: >-
+      A list of requests to be applied to the document. For this action, it will contain one
+      InsertTableColumnRequest.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document to update.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_INSERT_TABLE_COLUMN
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_insert_table_column
+      requests: '{requests}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_INSERT_TABLE_COLUMN

--- a/typescript/packages/composio/tools/composio_googledocs_insert_text_action/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_insert_text_action/definition.yaml
@@ -1,0 +1,82 @@
+name: composio_googledocs_insert_text_action
+description: >-
+  Tool to insert a string of text at a specified location within a google document. use when you
+  need to add new text content to an existing document.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document to insert text into.
+    required: true
+  text_to_insert:
+    type: string
+    description: The string of text to insert.
+    required: true
+  insertion_index:
+    type: number
+    description: >-
+      The EOL character of the paragraph will be moved to the end of the inserted text. The index
+      where the text will be inserted. The index is zero-based and refers to the UTF-16 code unit.
+      For example, to insert text at the beginning of the document, use an index of 1 (to account
+      for the first paragraph).
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_INSERT_TEXT_ACTION
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_insert_text_action
+      document_id: '{document_id}'
+      text_to_insert: '{text_to_insert}'
+      insertion_index: '{insertion_index}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_INSERT_TEXT_ACTION

--- a/typescript/packages/composio/tools/composio_googledocs_list_spreadsheet_charts_action/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_list_spreadsheet_charts_action/definition.yaml
@@ -1,0 +1,75 @@
+name: composio_googledocs_list_spreadsheet_charts_action
+description: >-
+  Tool to retrieve a list of charts with their ids and metadata from a google sheets spreadsheet.
+  use to identify charts available for embedding into google docs.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  fields_mask:
+    type: string
+    description: >-
+      Field mask to specify which parts of the spreadsheet and chart resources to include. Example:
+      '''sheets(properties(sheetId,title),charts(chartId,spec(title,altText)))'''
+    default: sheets(properties(sheetId,title),charts(chartId,spec(title,altText)))
+  spreadsheet_id:
+    type: string
+    description: The ID of the Google Sheets spreadsheet.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_LIST_SPREADSHEET_CHARTS_ACTION
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_list_spreadsheet_charts_action
+      fields_mask: '{fields_mask}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_LIST_SPREADSHEET_CHARTS_ACTION

--- a/typescript/packages/composio/tools/composio_googledocs_replace_all_text/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_replace_all_text/definition.yaml
@@ -1,0 +1,96 @@
+name: composio_googledocs_replace_all_text
+description: >-
+  Tool to replace all occurrences of a specified text string with another text string throughout a
+  google document. use when you need to perform a global find and replace operation within a
+  document.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  tab_ids:
+    type: array
+    description: >-
+      Optional. A list of specific tab IDs to perform the replacement on. If not provided,
+      replacement occurs on all tabs.
+    default: null
+  find_text:
+    type: string
+    description: The text to search for in the document.
+    required: true
+  match_case:
+    type: boolean
+    description: Indicates whether the search should be case sensitive.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document to update.
+    required: true
+  replace_text:
+    type: string
+    description: The text that will replace the matched text.
+    required: true
+  search_by_regex:
+    type: boolean
+    description: Optional. If True, the find_text is treated as a regular expression. Defaults to False.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_REPLACE_ALL_TEXT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_replace_all_text
+      tab_ids: '{tab_ids}'
+      find_text: '{find_text}'
+      match_case: '{match_case}'
+      document_id: '{document_id}'
+      replace_text: '{replace_text}'
+      search_by_regex: '{search_by_regex}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_REPLACE_ALL_TEXT

--- a/typescript/packages/composio/tools/composio_googledocs_replace_image/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_replace_image/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_replace_image
+description: >-
+  Tool to replace a specific image in a document with a new image from a uri. use when you need to
+  update an existing image within a google doc.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document containing the image to replace.
+    required: true
+  replace_image:
+    type: object
+    description: The details of the image replacement request.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_REPLACE_IMAGE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_replace_image
+      document_id: '{document_id}'
+      replace_image: '{replace_image}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_REPLACE_IMAGE

--- a/typescript/packages/composio/tools/composio_googledocs_search_documents/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_search_documents/definition.yaml
@@ -1,0 +1,106 @@
+name: composio_googledocs_search_documents
+description: Search for google documents using various filters including name, content, date ranges, and more.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  query:
+    type: string
+    description: >-
+      Search query to filter documents. Can search by name (name contains 'report'), full text
+      content (fullText contains 'important'), or use complex queries with operators like 'and',
+      'or', 'not'. Leave empty to get all documents.
+    default: null
+  order_by:
+    type: string
+    description: >-
+      Order results by field. Common options: 'modifiedTime desc', 'modifiedTime asc', 'name',
+      'createdTime desc'
+    default: modifiedTime desc
+  max_results:
+    type: number
+    description: Maximum number of documents to return (1-1000). Defaults to 10.
+    default: 10
+  starred_only:
+    type: boolean
+    description: Whether to return only starred documents. Defaults to False.
+    default: false
+  created_after:
+    type: string
+    description: Return documents created after this date. Use RFC 3339 format like '2024-01-01T00:00:00Z'.
+    default: null
+  modified_after:
+    type: string
+    description: Return documents modified after this date. Use RFC 3339 format like '2024-01-01T00:00:00Z'.
+    default: null
+  shared_with_me:
+    type: boolean
+    description: Whether to return only documents shared with the current user. Defaults to False.
+    default: false
+  include_trashed:
+    type: boolean
+    description: Whether to include documents in trash. Defaults to False.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_SEARCH_DOCUMENTS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_search_documents
+      query: '{query}'
+      order_by: '{order_by}'
+      max_results: '{max_results}'
+      starred_only: '{starred_only}'
+      created_after: '{created_after}'
+      modified_after: '{modified_after}'
+      shared_with_me: '{shared_with_me}'
+      include_trashed: '{include_trashed}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_SEARCH_DOCUMENTS

--- a/typescript/packages/composio/tools/composio_googledocs_unmerge_table_cells/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_unmerge_table_cells/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googledocs_unmerge_table_cells
+description: >-
+  Tool to unmerge previously merged cells in a table. use this when you need to revert merged cells
+  in a google document table back to their individual cell states.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  tableRange:
+    type: object
+    description: The table range specifying which cells of the table to unmerge.
+    required: true
+  document_id:
+    type: string
+    description: The ID of the document to unmerge table cells in.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_UNMERGE_TABLE_CELLS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_unmerge_table_cells
+      tableRange: '{tableRange}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_UNMERGE_TABLE_CELLS

--- a/typescript/packages/composio/tools/composio_googledocs_update_document_markdown/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_update_document_markdown/definition.yaml
@@ -1,0 +1,75 @@
+name: composio_googledocs_update_document_markdown
+description: >-
+  Replaces the entire content of an existing google docs document with new markdown text; requires
+  edit permissions for the document.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  document_id:
+    type: string
+    description: Identifier of the Google Docs document to update, found in the document's URL.
+    required: true
+  new_markdown_text:
+    type: string
+    description: >-
+      Markdown content that will replace the document's entire existing content. Supports standard
+      Markdown features.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_UPDATE_DOCUMENT_MARKDOWN
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_update_document_markdown
+      document_id: '{document_id}'
+      new_markdown_text: '{new_markdown_text}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_UPDATE_DOCUMENT_MARKDOWN

--- a/typescript/packages/composio/tools/composio_googledocs_update_document_style/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_update_document_style/definition.yaml
@@ -1,0 +1,85 @@
+name: composio_googledocs_update_document_style
+description: >-
+  Tool to update the overall document style, such as page size, margins, and default text direction.
+  use when you need to modify the global style settings of a google document.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  fields:
+    type: string
+    description: >-
+      A comma-separated list of fields to update. Use '*' to update all fields in document_style.
+      For example: "pageSize,marginTop,marginBottom".
+    required: true
+  tab_id:
+    type: string
+    description: The ID of the tab to update the style for. If not provided, the first tab is used.
+    default: null
+  document_id:
+    type: string
+    description: The ID of the document to update.
+    required: true
+  document_style:
+    type: object
+    description: The DocumentStyle object with the new style settings.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_UPDATE_DOCUMENT_STYLE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_update_document_style
+      fields: '{fields}'
+      tab_id: '{tab_id}'
+      document_id: '{document_id}'
+      document_style: '{document_style}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_UPDATE_DOCUMENT_STYLE

--- a/typescript/packages/composio/tools/composio_googledocs_update_existing_document/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_update_existing_document/definition.yaml
@@ -1,0 +1,113 @@
+name: composio_googledocs_update_existing_document
+description: >-
+  Applies programmatic edits, such as text insertion, deletion, or formatting, to a specified google
+  doc using the `batchupdate` api method.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  editDocs:
+    type: array
+    description: >-
+      Requests conforming to the Google Docs API `batchUpdate` method, where each item specifies an
+      operation. For full details and more request types, see
+      https://developers.google.com/docs/api/reference/rest/v1/documents/batchUpdate.
+
+      For example, to insert text at the beginning of the document:
+
+      [
+        {
+          "insertText": {
+            "text": "This is a new paragraph.\n",
+            "location": {
+              "index": 1
+            }
+          }
+        }
+      ]
+
+
+      To delete a paragraph by its index:
+
+      [{
+        "deleteContentRange": {
+          "range": {
+            "startIndex": 1,
+            "endIndex": 20
+          }
+        }
+      }]
+
+
+      To replace all text:
+
+      [{
+        "replaceAllText": {
+          "containsText": {
+            "text": "old text"
+          },
+          "replaceText": "new text"
+        }
+      }]
+    required: true
+  document_id:
+    type: string
+    description: The unique identifier of the Google Docs document to be updated.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_UPDATE_EXISTING_DOCUMENT
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_update_existing_document
+      editDocs: '{editDocs}'
+      document_id: '{document_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_UPDATE_EXISTING_DOCUMENT

--- a/typescript/packages/composio/tools/composio_googledocs_update_table_row_style/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googledocs_update_table_row_style/definition.yaml
@@ -1,0 +1,74 @@
+name: composio_googledocs_update_table_row_style
+description: >-
+  Tool to update the style of a table row in a google document. use when you need to modify the
+  appearance of specific rows within a table, such as setting minimum row height or marking rows as
+  headers.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEDOCS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEDOCS" flow must be completed before this tool will succeed.
+    required: true
+  documentId:
+    type: string
+    description: The ID of the document to update.
+    required: true
+  updateTableRowStyle:
+    type: object
+    description: The updateTableRowStyle parameter.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEDOCS_UPDATE_TABLE_ROW_STYLE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googledocs_update_table_row_style
+      documentId: '{documentId}'
+      updateTableRowStyle: '{updateTableRowStyle}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googledocs
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googledocs
+  composio_slug: GOOGLEDOCS_UPDATE_TABLE_ROW_STYLE

--- a/typescript/packages/composio/tools/composio_googleforms_batch_update_form/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googleforms_batch_update_form/definition.yaml
@@ -1,0 +1,111 @@
+name: composio_googleforms_batch_update_form
+description: >-
+  Applies a batch of update operations to a Google Form in a single atomic transaction. Use when you
+  need to modify form content after creation, including: - Adding, updating, or deleting questions
+  and other items - Modifying form metadata (title, description) - Updating form settings (quiz
+  mode, email collection) - Reorganizing item order within the form All updates in the batch are
+  applied together atomically. If any update fails, the entire batch is rolled back. Use
+  writeControl for optimistic concurrency to ensure updates are applied to the expected form
+  version. Note: The form must have the appropriate sharing settings for the authenticated user to
+  modify it.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEFORMS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEFORMS" flow must be completed before this tool will succeed.
+    required: true
+  formId:
+    type: string
+    description: Required. The ID of the form to update.
+    required: true
+  requests:
+    type: array
+    description: >-
+      Required. The update requests to apply to the form. Each request is a dictionary containing
+      exactly one request type:
+
+
+      **Available request types:**
+
+      - `createItem` - Add a new item (question) to the form. Requires `item` (the item definition)
+      and `location` (where to place it).
+
+      - `updateFormInfo` - Update form metadata. Requires `info` (title, description) and
+      `updateMask` (fields to update).
+
+      - `updateSettings` - Update form settings. Requires `settings` and `updateMask`.
+
+      - `updateItem` - Update an existing item. Requires `item`, `location`, and `updateMask`.
+
+      - `moveItem` - Move an item to a new location. Requires `originalLocation` and `newLocation`.
+
+      - `deleteItem` - Delete an item. Requires `location` with the index of the item to delete.
+
+
+      All updates are applied atomically - if any update fails, the entire batch is rolled back.
+    required: true
+  writeControl:
+    type: object
+    description: Provides control over how write requests are executed.
+  includeFormInResponse:
+    type: boolean
+    description: >-
+      Whether to return the updated form in the response. Set to true to get the complete form with
+      all applied mutations.
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEFORMS_BATCH_UPDATE_FORM
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googleforms_batch_update_form
+      formId: '{formId}'
+      requests: '{requests}'
+      writeControl: '{writeControl}'
+      includeFormInResponse: '{includeFormInResponse}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googleforms
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googleforms
+  composio_slug: GOOGLEFORMS_BATCH_UPDATE_FORM

--- a/typescript/packages/composio/tools/composio_googleforms_create_form/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googleforms_create_form/definition.yaml
@@ -1,0 +1,80 @@
+name: composio_googleforms_create_form
+description: >-
+  Creates a new Google Form with the specified title. This action initializes an empty form that can
+  be later populated with items (questions, sections, images, videos) using the batchUpdate
+  endpoint. When a form is created, it is assigned a unique formId that is required for all
+  subsequent operations on that form. As of June 30, 2026, forms created via API will default to an
+  unpublished state, giving creators control over responder access before making the form publicly
+  available. Use this action when you need to create a new form for collecting information, surveys,
+  quizzes, or feedback. After creation, use the batchUpdate action to add questions and other items
+  to the form.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEFORMS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEFORMS" flow must be completed before this tool will succeed.
+    required: true
+  info:
+    type: object
+    description: Required. Form info object containing the title and optional document title.
+    required: true
+  unpublished:
+    type: boolean
+    description: >-
+      Optional. Whether the form is unpublished. If set to true, the form doesn't accept responses.
+      If set to false or unset, the form is published and accepts responses.
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEFORMS_CREATE_FORM
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googleforms_create_form
+      info: '{info}'
+      unpublished: '{unpublished}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googleforms
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googleforms
+  composio_slug: GOOGLEFORMS_CREATE_FORM

--- a/typescript/packages/composio/tools/composio_googleforms_get_form/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googleforms_get_form/definition.yaml
@@ -1,0 +1,75 @@
+name: composio_googleforms_get_form
+description: >-
+  Retrieves the complete structure and metadata of a Google Form. Returns the full form definition
+  including its title, description, all items (questions, sections, page breaks, images, videos, and
+  display text), form settings (quiz mode, email collection), publishing state, and output-only
+  fields such as the responder submission URL and revision ID. This action is read-only and does not
+  modify the form. Use this action when you need to read the current configuration of a form,
+  display its structure to users, inspect its settings, or check its publishing state before making
+  updates.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEFORMS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEFORMS" flow must be completed before this tool will succeed.
+    required: true
+  formId:
+    type: string
+    description: >-
+      Required. The unique ID of the form to retrieve. The form ID can be found in the URL after
+      'forms/d/' when viewing the form in Google Forms.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEFORMS_GET_FORM
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googleforms_get_form
+      formId: '{formId}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googleforms
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googleforms
+  composio_slug: GOOGLEFORMS_GET_FORM

--- a/typescript/packages/composio/tools/composio_googleforms_get_response/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googleforms_get_response/definition.yaml
@@ -1,0 +1,78 @@
+name: composio_googleforms_get_response
+description: >-
+  Retrieves a single form response by its unique response ID. Returns complete response data
+  including all answers provided by the respondent, their email (if collected), timestamps, and quiz
+  scores (if applicable). Use this action when you need to fetch detailed information about a
+  specific submission, such as viewing individual submissions, verifying response data, or building
+  response detail views.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEFORMS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEFORMS" flow must be completed before this tool will succeed.
+    required: true
+  form_id:
+    type: string
+    description: Required. The form ID of the form to retrieve a response from.
+    required: true
+  response_id:
+    type: string
+    description: >-
+      Required. The response ID to retrieve. This is the unique identifier for a specific form
+      submission.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEFORMS_GET_RESPONSE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googleforms_get_response
+      form_id: '{form_id}'
+      response_id: '{response_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googleforms
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googleforms
+  composio_slug: GOOGLEFORMS_GET_RESPONSE

--- a/typescript/packages/composio/tools/composio_googleforms_list_responses/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googleforms_list_responses/definition.yaml
@@ -1,0 +1,91 @@
+name: composio_googleforms_list_responses
+description: >-
+  Lists all responses submitted to a Google Form with optional filtering and pagination. Use this
+  action to retrieve multiple form submissions at once, export response data, or monitor new
+  submissions. Supports filtering by timestamp to fetch only responses submitted after a specific
+  time, which is useful for incremental data synchronization.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEFORMS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEFORMS" flow must be completed before this tool will succeed.
+    required: true
+  filter:
+    type: string
+    description: >-
+      A filter expression to return only responses that match the specified condition. Supports
+      timestamp > N or timestamp >= N in RFC3339 UTC 'Zulu' format (e.g., '2024-01-15T00:00:00Z').
+      Use this for incremental data synchronization to fetch only new responses.
+  form_id:
+    type: string
+    description: >-
+      Required. The ID of the Form whose responses to list. You can find the form ID in the form
+      URL: https://forms.google.com/forms/d/{formId}/edit
+    required: true
+  page_size:
+    type: number
+    description: >-
+      The maximum number of responses to return. If unspecified, at most 5000 responses are
+      returned. Use pageToken to iterate through pages.
+  page_token:
+    type: string
+    description: >-
+      A page token returned by a previous list response. Use this to retrieve the next page of
+      results.
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEFORMS_LIST_RESPONSES
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googleforms_list_responses
+      filter: '{filter}'
+      form_id: '{form_id}'
+      page_size: '{page_size}'
+      page_token: '{page_token}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googleforms
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googleforms
+  composio_slug: GOOGLEFORMS_LIST_RESPONSES

--- a/typescript/packages/composio/tools/composio_googleforms_list_watches/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googleforms_list_watches/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googleforms_list_watches
+description: >-
+  Lists all watches owned by the calling project for a specific Google Form. Use this action to
+  discover existing watches, check their status and expiration times, or audit which notifications
+  are configured for a form. Each project can have a maximum of 2 watches per form (one for each
+  event type: SCHEMA and RESPONSES). The SCHEMA event type monitors changes to form content or
+  settings, while RESPONSES monitors new form submissions.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEFORMS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEFORMS" flow must be completed before this tool will succeed.
+    required: true
+  form_id:
+    type: string
+    description: >-
+      Required. ID of the Form whose watches to list. The form ID can be found in the form URL:
+      https://docs.google.com/forms/d/{formId}/edit
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEFORMS_LIST_WATCHES
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googleforms_list_watches
+      form_id: '{form_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googleforms
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googleforms
+  composio_slug: GOOGLEFORMS_LIST_WATCHES

--- a/typescript/packages/composio/tools/composio_googleforms_set_publish_settings/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googleforms_set_publish_settings/definition.yaml
@@ -1,0 +1,82 @@
+name: composio_googleforms_set_publish_settings
+description: >-
+  Updates the publishing settings of a Google Form, controlling whether the form is published
+  (visible to others) and whether it accepts responses. Use this action to publish a draft form,
+  unpublish a form to prevent access, or toggle response collection on/off without changing the
+  form's visibility. Note that legacy forms created before the publish settings feature was
+  introduced cannot use this endpoint and will return an error.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEFORMS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEFORMS" flow must be completed before this tool will succeed.
+    required: true
+  form_id:
+    type: string
+    description: Required. The ID of the form to update. You can get the form ID from the Form.form_id field.
+    required: true
+  updateMask:
+    type: string
+    description: >-
+      Optional. The publishSettings fields to update. Accepts: 'publishState' or '*' for all fields.
+      If not provided, all fields are updated.
+  publishSettings:
+    type: object
+    description: Required. The desired publish settings to apply to the form.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEFORMS_SET_PUBLISH_SETTINGS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googleforms_set_publish_settings
+      form_id: '{form_id}'
+      updateMask: '{updateMask}'
+      publishSettings: '{publishSettings}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googleforms
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googleforms
+  composio_slug: GOOGLEFORMS_SET_PUBLISH_SETTINGS

--- a/typescript/packages/composio/tools/composio_googlemeet_create_meet/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_create_meet/definition.yaml
@@ -1,0 +1,80 @@
+name: composio_googlemeet_create_meet
+description: >-
+  Creates a new google meet space, optionally configuring its access type and entry point access
+  controls.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  access_type:
+    type: string
+    description: Access control level for the meeting space.
+    enum:
+      - OPEN
+      - TRUSTED
+      - RESTRICTED
+      - ACCESS_TYPE_UNSPECIFIED
+  entry_point_access:
+    type: string
+    description: Access control for meeting entry points.
+    enum:
+      - ENTRY_POINT_ACCESS_UNSPECIFIED
+      - ALL
+      - CREATOR_APP_ONLY
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_CREATE_MEET
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_create_meet
+      access_type: '{access_type}'
+      entry_point_access: '{entry_point_access}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_CREATE_MEET

--- a/typescript/packages/composio/tools/composio_googlemeet_get_conference_record_for_meet/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_get_conference_record_for_meet/definition.yaml
@@ -1,0 +1,81 @@
+name: composio_googlemeet_get_conference_record_for_meet
+description: Get conference record
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  end_time:
+    type: string
+    description: The end time of the meeting.
+    default: null
+  space_name:
+    type: string
+    description: The name of the Google Meet space.
+    default: null
+  start_time:
+    type: string
+    description: The start time of the meeting.
+    default: null
+  meeting_code:
+    type: string
+    description: The meeting code of the Google Meet space.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_GET_CONFERENCE_RECORD_FOR_MEET
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_get_conference_record_for_meet
+      end_time: '{end_time}'
+      space_name: '{space_name}'
+      start_time: '{start_time}'
+      meeting_code: '{meeting_code}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_GET_CONFERENCE_RECORD_FOR_MEET

--- a/typescript/packages/composio/tools/composio_googlemeet_get_meet/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_get_meet/definition.yaml
@@ -1,0 +1,66 @@
+name: composio_googlemeet_get_meet
+description: Retrieve details of a google meet space using its unique identifier.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  space_name:
+    type: string
+    description: The unique identifier for the Google Meet space.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_GET_MEET
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_get_meet
+      space_name: '{space_name}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_GET_MEET

--- a/typescript/packages/composio/tools/composio_googlemeet_get_participant_session/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_get_participant_session/definition.yaml
@@ -1,0 +1,70 @@
+name: composio_googlemeet_get_participant_session
+description: >-
+  Tool to get a specific participant session from a conference record. use when you need to retrieve
+  details about a particular participant in a past meeting.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  name:
+    type: string
+    description: >-
+      Required. Resource name of the participant. Format:
+      conferenceRecords/{conference_record}/participants/{participant}
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_GET_PARTICIPANT_SESSION
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_get_participant_session
+      name: '{name}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_GET_PARTICIPANT_SESSION

--- a/typescript/packages/composio/tools/composio_googlemeet_get_recordings_by_conference_record_id/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_get_recordings_by_conference_record_id/definition.yaml
@@ -1,0 +1,67 @@
+name: composio_googlemeet_get_recordings_by_conference_record_id
+description: Retrieves recordings from google meet for a given conference record id.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  conferenceRecord_id:
+    type: string
+    description: Unique identifier for the conference record.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: >-
+    https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_GET_RECORDINGS_BY_CONFERENCE_RECORD_ID
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_get_recordings_by_conference_record_id
+      conferenceRecord_id: '{conferenceRecord_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_GET_RECORDINGS_BY_CONFERENCE_RECORD_ID

--- a/typescript/packages/composio/tools/composio_googlemeet_get_transcripts_by_conference_record_id/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_get_transcripts_by_conference_record_id/definition.yaml
@@ -1,0 +1,67 @@
+name: composio_googlemeet_get_transcripts_by_conference_record_id
+description: Retrieves all transcripts for a specific google meet conference using its conferencerecord id.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  conferenceRecord_id:
+    type: string
+    description: Unique identifier of the conference record.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: >-
+    https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_GET_TRANSCRIPTS_BY_CONFERENCE_RECORD_ID
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_get_transcripts_by_conference_record_id
+      conferenceRecord_id: '{conferenceRecord_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_GET_TRANSCRIPTS_BY_CONFERENCE_RECORD_ID

--- a/typescript/packages/composio/tools/composio_googlemeet_list_conference_records/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_list_conference_records/definition.yaml
@@ -1,0 +1,85 @@
+name: composio_googlemeet_list_conference_records
+description: >-
+  Tool to list conference records. use when you need to retrieve a list of past conferences,
+  optionally filtering them by criteria like meeting code, space name, or time range.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  filter:
+    type: string
+    description: >-
+      Optional. User specified filtering condition in EBNF format. Filterable fields:
+      `space.meeting_code`, `space.name`, `start_time`, `end_time`. Examples: `space.name =
+      "spaces/NAME"`, `space.meeting_code = "abc-mnop-xyz"`, `start_time>="2024-01-01T00:00:00.000Z"
+      AND start_time<="2024-01-02T00:00:00.000Z"`, `end_time IS NULL`
+    default: null
+  page_size:
+    type: number
+    description: >-
+      Maximum number of conference records to return. The service might return fewer than this
+      value. If unspecified, at most 25 conference records are returned. The maximum value is 100;
+      values above 100 are coerced to 100.
+    default: null
+  page_token:
+    type: string
+    description: Page token returned from previous List Call.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_LIST_CONFERENCE_RECORDS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_list_conference_records
+      filter: '{filter}'
+      page_size: '{page_size}'
+      page_token: '{page_token}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_LIST_CONFERENCE_RECORDS

--- a/typescript/packages/composio/tools/composio_googlemeet_list_participant_sessions/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_list_participant_sessions/definition.yaml
@@ -1,0 +1,92 @@
+name: composio_googlemeet_list_participant_sessions
+description: >-
+  Tool to list all participant sessions for a specific conference record in google meet. use this
+  when you need to retrieve a list of participants who joined a particular meeting.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  filter:
+    type: string
+    description: >-
+      Optional. User-specified filtering condition in EBNF format. Filterable fields include
+      `earliest_start_time` and `latest_end_time`.
+    default: null
+  parent:
+    type: string
+    description: >-
+      Required. The identifier of the conference record, in the format
+      `conferenceRecords/{conferenceRecord}`.
+    required: true
+  page_size:
+    type: number
+    description: >-
+      Optional. Maximum number of participants to return. The service might return fewer than this
+      value. If unspecified, at most 100 participants are returned. The maximum value is 250; values
+      above 250 are coerced to 250.
+    default: null
+  page_token:
+    type: string
+    description: >-
+      Optional. Page token returned from a previous list call, used to retrieve the next page of
+      results.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_LIST_PARTICIPANT_SESSIONS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_list_participant_sessions
+      filter: '{filter}'
+      parent: '{parent}'
+      page_size: '{page_size}'
+      page_token: '{page_token}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_LIST_PARTICIPANT_SESSIONS

--- a/typescript/packages/composio/tools/composio_googlemeet_update_space/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlemeet_update_space/definition.yaml
@@ -1,0 +1,82 @@
+name: composio_googlemeet_update_space
+description: >-
+  Updates a meeting space. use this tool to modify the settings of an existing google meet space.
+  requires the space resource in the request body and the space name in the path.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLEMEET toolkit, scoped to the calling tenant.
+      The "Connect GOOGLEMEET" flow must be completed before this tool will succeed.
+    required: true
+  name:
+    type: string
+    description: 'Immutable. Resource name of the space. Format: `spaces/{space}`.'
+    required: true
+  config:
+    type: object
+    description: Configuration pertaining to the meeting space.
+    default: null
+  updateMask:
+    type: string
+    description: >-
+      Optional. Field mask used to specify the fields to be updated. Comma-separated list of fully
+      qualified field names. Example:
+      "config.accessType,config.moderationRestrictions.chatRestriction". Use "*" to update all
+      fields.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLEMEET_UPDATE_SPACE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlemeet_update_space
+      name: '{name}'
+      config: '{config}'
+      updateMask: '{updateMask}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlemeet
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlemeet
+  composio_slug: GOOGLEMEET_UPDATE_SPACE

--- a/typescript/packages/composio/tools/composio_googlesheets_add_sheet/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_add_sheet/definition.yaml
@@ -1,0 +1,89 @@
+name: composio_googlesheets_add_sheet
+description: >-
+  Adds a new sheet (worksheet) to a spreadsheet. use this tool to create a new tab within an
+  existing google sheet, optionally specifying its title, index, size, and other properties.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  properties:
+    type: object
+    description: >-
+      The properties the new sheet should have. All properties are optional. If none are specified,
+      a default sheet will be created.
+    default: null
+  spreadsheetId:
+    type: string
+    description: >-
+      The ID of the spreadsheet to add the sheet to. This is the long string of characters in the
+      URL of your Google Sheet.
+    required: true
+  responseIncludeGridData:
+    type: boolean
+    description: >-
+      True if grid data should be returned. This parameter is ignored if
+      includeSpreadsheetInResponse is false. Defaults to false.
+    default: false
+  includeSpreadsheetInResponse:
+    type: boolean
+    description: Whether the response should include the entire spreadsheet resource. Defaults to false.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_ADD_SHEET
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_add_sheet
+      properties: '{properties}'
+      spreadsheetId: '{spreadsheetId}'
+      responseIncludeGridData: '{responseIncludeGridData}'
+      includeSpreadsheetInResponse: '{includeSpreadsheetInResponse}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_ADD_SHEET

--- a/typescript/packages/composio/tools/composio_googlesheets_aggregate_column_data/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_aggregate_column_data/definition.yaml
@@ -1,0 +1,123 @@
+name: composio_googlesheets_aggregate_column_data
+description: >-
+  Searches for rows where a specific column matches a value and performs mathematical operations on
+  data from another column.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  operation:
+    type: string
+    description: The mathematical operation to perform on the target column values.
+    required: true
+    enum:
+      - sum
+      - average
+      - count
+      - min
+      - max
+      - percentage
+  sheet_name:
+    type: string
+    description: The name of the specific sheet within the spreadsheet.
+    required: true
+  search_value:
+    type: string
+    description: The exact value to search for in the search column. Case-sensitive by default.
+    required: true
+  search_column:
+    type: string
+    description: >-
+      The column to search in. Can be a letter (e.g., 'A', 'B') or column name from header row
+      (e.g., 'Region', 'Department').
+    required: true
+  target_column:
+    type: string
+    description: >-
+      The column to aggregate data from. Can be a letter (e.g., 'C', 'D') or column name from header
+      row (e.g., 'Sales', 'Revenue').
+    required: true
+  case_sensitive:
+    type: boolean
+    description: Whether the search should be case-sensitive.
+    default: true
+  has_header_row:
+    type: boolean
+    description: >-
+      Whether the first row contains column headers. If True, column names can be used for
+      search_column and target_column.
+    default: true
+  spreadsheet_id:
+    type: string
+    description: The unique identifier of the Google Sheets spreadsheet.
+    required: true
+  percentage_total:
+    type: number
+    description: >-
+      For percentage operation, the total value to calculate percentage against. If not provided,
+      uses sum of all values in target column.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_AGGREGATE_COLUMN_DATA
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_aggregate_column_data
+      operation: '{operation}'
+      sheet_name: '{sheet_name}'
+      search_value: '{search_value}'
+      search_column: '{search_column}'
+      target_column: '{target_column}'
+      case_sensitive: '{case_sensitive}'
+      has_header_row: '{has_header_row}'
+      spreadsheet_id: '{spreadsheet_id}'
+      percentage_total: '{percentage_total}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_AGGREGATE_COLUMN_DATA

--- a/typescript/packages/composio/tools/composio_googlesheets_append_dimension/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_append_dimension/definition.yaml
@@ -1,0 +1,86 @@
+name: composio_googlesheets_append_dimension
+description: >-
+  Tool to append new rows or columns to a sheet, increasing its size. use when you need to add empty
+  rows or columns to an existing sheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  length:
+    type: number
+    description: The number of rows or columns to append.
+    required: true
+  sheet_id:
+    type: number
+    description: The ID of the sheet to append rows or columns to.
+    required: true
+  dimension:
+    type: string
+    description: Specifies whether to append rows or columns.
+    required: true
+    enum:
+      - ROWS
+      - COLUMNS
+  spreadsheet_id:
+    type: string
+    description: The ID of the spreadsheet.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_APPEND_DIMENSION
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_append_dimension
+      length: '{length}'
+      sheet_id: '{sheet_id}'
+      dimension: '{dimension}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_APPEND_DIMENSION

--- a/typescript/packages/composio/tools/composio_googlesheets_batch_get/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_batch_get/definition.yaml
@@ -1,0 +1,76 @@
+name: composio_googlesheets_batch_get
+description: >-
+  Retrieves data from specified cell ranges in a google spreadsheet; ensure the spreadsheet has at
+  least one worksheet and any explicitly referenced sheet names in ranges exist.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  ranges:
+    type: array
+    description: >-
+      A list of cell ranges in A1 notation (e.g., 'Sheet1!A1:B2', 'A1:C5') from which to retrieve
+      data. If this list is omitted or empty, all data from the first sheet of the spreadsheet will
+      be fetched. A range can specify a sheet name (e.g., 'Sheet2!A:A'); if no sheet name is
+      provided in a range string (e.g., 'A1:B2'), it defaults to the first sheet.
+  spreadsheet_id:
+    type: string
+    description: The unique identifier of the Google Spreadsheet from which data will be retrieved.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_BATCH_GET
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_batch_get
+      ranges: '{ranges}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_BATCH_GET

--- a/typescript/packages/composio/tools/composio_googlesheets_batch_update/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_batch_update/definition.yaml
@@ -1,0 +1,104 @@
+name: composio_googlesheets_batch_update
+description: >-
+  Updates a specified range in a google sheet with given values, or appends them as new rows if
+  `first cell location` is omitted; ensure the target sheet exists and the spreadsheet contains at
+  least one worksheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  values:
+    type: array
+    description: >-
+      A 2D list of cell values. Each inner list represents a row. Values can be strings, numbers, or
+      booleans. Ensure columns are properly aligned across rows.
+    required: true
+  sheet_name:
+    type: string
+    description: The name of the specific sheet within the spreadsheet to update.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The unique identifier of the Google Sheets spreadsheet to be updated.
+    required: true
+  valueInputOption:
+    type: string
+    description: >-
+      How input data is interpreted. 'USER_ENTERED': Values parsed as if typed by a user (e.g.,
+      strings may become numbers/dates, formulas are calculated); recommended for formulas. 'RAW':
+      Values stored as-is without parsing (e.g., '123' stays string, '=SUM(A1:B1)' stays string).
+    enum:
+      - RAW
+      - USER_ENTERED
+    default: USER_ENTERED
+  first_cell_location:
+    type: string
+    description: >-
+      The starting cell for the update range, specified in A1 notation (e.g., 'A1', 'B2'). The
+      update will extend from this cell to the right and down, based on the provided values. If
+      omitted, values are appended to the sheet.
+  includeValuesInResponse:
+    type: boolean
+    description: If set to True, the response will include the updated values from the spreadsheet.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_BATCH_UPDATE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_batch_update
+      values: '{values}'
+      sheet_name: '{sheet_name}'
+      spreadsheet_id: '{spreadsheet_id}'
+      valueInputOption: '{valueInputOption}'
+      first_cell_location: '{first_cell_location}'
+      includeValuesInResponse: '{includeValuesInResponse}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_BATCH_UPDATE

--- a/typescript/packages/composio/tools/composio_googlesheets_batch_update_values_by_data_filter/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_batch_update_values_by_data_filter/definition.yaml
@@ -1,0 +1,113 @@
+name: composio_googlesheets_batch_update_values_by_data_filter
+description: >-
+  Tool to update values in ranges matching data filters. use when you need to update specific data
+  in a google sheet based on criteria rather than fixed cell ranges.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  data:
+    type: array
+    description: >-
+      The new values to apply to the spreadsheet. If more than one range is matched by the specified
+      DataFilter the specified values are applied to all of those ranges.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet to update.
+    required: true
+  valueInputOption:
+    type: string
+    description: How the input data should be interpreted.
+    required: true
+    enum:
+      - RAW
+      - USER_ENTERED
+  includeValuesInResponse:
+    type: boolean
+    description: >-
+      Determines if the update response should include the values of the cells that were updated. By
+      default, responses do not include the updated values.
+    default: false
+  responseValueRenderOption:
+    type: string
+    description: >-
+      Determines how values in the response should be rendered. The default render option is
+      FORMATTED_VALUE.
+    enum:
+      - FORMATTED_VALUE
+      - UNFORMATTED_VALUE
+      - FORMULA
+    default: FORMATTED_VALUE
+  responseDateTimeRenderOption:
+    type: string
+    description: >-
+      Determines how dates, times, and durations in the response should be rendered. This is ignored
+      if responseValueRenderOption is FORMATTED_VALUE. The default dateTime render option is
+      SERIAL_NUMBER.
+    enum:
+      - SERIAL_NUMBER
+      - FORMATTED_STRING
+    default: SERIAL_NUMBER
+execution:
+  type: http
+  method: POST
+  url: >-
+    https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_BATCH_UPDATE_VALUES_BY_DATA_FILTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_batch_update_values_by_data_filter
+      data: '{data}'
+      spreadsheetId: '{spreadsheetId}'
+      valueInputOption: '{valueInputOption}'
+      includeValuesInResponse: '{includeValuesInResponse}'
+      responseValueRenderOption: '{responseValueRenderOption}'
+      responseDateTimeRenderOption: '{responseDateTimeRenderOption}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_BATCH_UPDATE_VALUES_BY_DATA_FILTER

--- a/typescript/packages/composio/tools/composio_googlesheets_clear_basic_filter/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_clear_basic_filter/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googlesheets_clear_basic_filter
+description: >-
+  Tool to clear the basic filter from a sheet. use when you need to remove an existing basic filter
+  from a specific sheet within a google spreadsheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sheet_id:
+    type: number
+    description: The ID of the sheet on which the basic filter should be cleared.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The ID of the spreadsheet.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_CLEAR_BASIC_FILTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_clear_basic_filter
+      sheet_id: '{sheet_id}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_CLEAR_BASIC_FILTER

--- a/typescript/packages/composio/tools/composio_googlesheets_clear_values/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_clear_values/definition.yaml
@@ -1,0 +1,78 @@
+name: composio_googlesheets_clear_values
+description: >-
+  Clears cell content (preserving formatting and notes) from a specified a1 notation range in a
+  google spreadsheet; the range must correspond to an existing sheet and cells.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  range:
+    type: string
+    description: >-
+      The A1 notation of the range to clear values from (e.g., 'Sheet1!A1:B2', 'MySheet!C:C', or
+      'A1:D5'). If the sheet name is omitted (e.g., 'A1:B2'), the operation applies to the first
+      visible sheet.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: >-
+      The unique identifier of the Google Spreadsheet from which to clear values. This ID can be
+      found in the URL of the spreadsheet.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_CLEAR_VALUES
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_clear_values
+      range: '{range}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_CLEAR_VALUES

--- a/typescript/packages/composio/tools/composio_googlesheets_create_chart/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_create_chart/definition.yaml
@@ -1,0 +1,127 @@
+name: composio_googlesheets_create_chart
+description: Create a chart in a google sheets spreadsheet using the specified data range and chart type.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  title:
+    type: string
+    description: Optional title for the chart.
+    default: null
+  sheet_id:
+    type: number
+    description: >-
+      The ID of the sheet within the spreadsheet where the chart will be created. Defaults to 0
+      (first sheet).
+    default: 0
+  subtitle:
+    type: string
+    description: Optional subtitle for the chart.
+    default: null
+  chart_type:
+    type: string
+    description: >-
+      The type of chart to create. Supported types: BAR, LINE, AREA, COLUMN, SCATTER, COMBO,
+      STEPPED_AREA.
+    required: true
+  data_range:
+    type: string
+    description: The range of data to use for the chart in A1 notation (e.g., 'A1:C10').
+    required: true
+  x_axis_title:
+    type: string
+    description: Optional title for the X-axis.
+    default: null
+  y_axis_title:
+    type: string
+    description: Optional title for the Y-axis.
+    default: null
+  background_red:
+    type: number
+    description: Red component of chart background color (0.0-1.0). If not specified, uses default.
+    default: null
+  spreadsheet_id:
+    type: string
+    description: The unique identifier of the Google Sheets spreadsheet where the chart will be created.
+    required: true
+  background_blue:
+    type: number
+    description: Blue component of chart background color (0.0-1.0). If not specified, uses default.
+    default: null
+  legend_position:
+    type: string
+    description: >-
+      Position of the chart legend. Options: BOTTOM_LEGEND, TOP_LEGEND, LEFT_LEGEND, RIGHT_LEGEND,
+      NO_LEGEND.
+    default: BOTTOM_LEGEND
+  background_green:
+    type: number
+    description: Green component of chart background color (0.0-1.0). If not specified, uses default.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_CREATE_CHART
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_create_chart
+      title: '{title}'
+      sheet_id: '{sheet_id}'
+      subtitle: '{subtitle}'
+      chart_type: '{chart_type}'
+      data_range: '{data_range}'
+      x_axis_title: '{x_axis_title}'
+      y_axis_title: '{y_axis_title}'
+      background_red: '{background_red}'
+      spreadsheet_id: '{spreadsheet_id}'
+      background_blue: '{background_blue}'
+      legend_position: '{legend_position}'
+      background_green: '{background_green}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_CREATE_CHART

--- a/typescript/packages/composio/tools/composio_googlesheets_create_google_sheet1/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_create_google_sheet1/definition.yaml
@@ -1,0 +1,66 @@
+name: composio_googlesheets_create_google_sheet1
+description: Creates a new google spreadsheet in google drive using the provided title.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  title:
+    type: string
+    description: The title for the new Google Sheet. This will be the name of the file in Google Drive.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_CREATE_GOOGLE_SHEET1
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_create_google_sheet1
+      title: '{title}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_CREATE_GOOGLE_SHEET1

--- a/typescript/packages/composio/tools/composio_googlesheets_create_spreadsheet_column/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_create_spreadsheet_column/definition.yaml
@@ -1,0 +1,92 @@
+name: composio_googlesheets_create_spreadsheet_column
+description: >-
+  Creates a new column in a google spreadsheet, requiring a valid `spreadsheet id` and an existing
+  `sheet id`; an out-of-bounds `insert index` may append/prepend the column.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sheet_id:
+    type: number
+    description: >-
+      The numeric identifier of the specific sheet (tab) within the spreadsheet where the column
+      will be added.
+    required: true
+  insert_index:
+    type: number
+    description: >-
+      The 0-based index at which the new column will be inserted. For example, an index of 0 inserts
+      the column before the current first column (A), and an index of 1 inserts it between the
+      current columns A and B.
+    default: 0
+  spreadsheet_id:
+    type: string
+    description: The unique identifier of the Google Spreadsheet where the column will be created.
+    required: true
+  inherit_from_before:
+    type: boolean
+    description: >-
+      If true, the new column inherits properties (e.g., formatting, width) from the column
+      immediately to its left (the preceding column). If false (default), it inherits from the
+      column immediately to its right (the succeeding column). This is ignored if there is no
+      respective preceding or succeeding column.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_CREATE_SPREADSHEET_COLUMN
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_create_spreadsheet_column
+      sheet_id: '{sheet_id}'
+      insert_index: '{insert_index}'
+      spreadsheet_id: '{spreadsheet_id}'
+      inherit_from_before: '{inherit_from_before}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_CREATE_SPREADSHEET_COLUMN

--- a/typescript/packages/composio/tools/composio_googlesheets_create_spreadsheet_row/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_create_spreadsheet_row/definition.yaml
@@ -1,0 +1,93 @@
+name: composio_googlesheets_create_spreadsheet_row
+description: >-
+  Inserts a new, empty row into a specified sheet of a google spreadsheet at a given index,
+  optionally inheriting formatting from the row above.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sheet_id:
+    type: number
+    description: >-
+      The numeric identifier of the sheet (tab) within the spreadsheet where the row will be
+      inserted. This ID (gid) is found in the URL of the spreadsheet (e.g., '0' for the first
+      sheet).
+    required: true
+  insert_index:
+    type: number
+    description: >-
+      The 0-based index at which the new row should be inserted. For example, an index of 0 inserts
+      the row at the beginning of the sheet. If the index is greater than the current number of
+      rows, the row is appended.
+    default: 0
+  spreadsheet_id:
+    type: string
+    description: >-
+      The unique identifier of the Google Spreadsheet. This ID is found in the URL of the
+      spreadsheet (e.g., '1qpyC0XzHc_-_d824s2VfopkHh7D0jW4aXCS1D_AlGA').
+    required: true
+  inherit_from_before:
+    type: boolean
+    description: >-
+      If True, the newly inserted row will inherit formatting and properties from the row
+      immediately preceding its insertion point. If False, it will have default formatting.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_CREATE_SPREADSHEET_ROW
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_create_spreadsheet_row
+      sheet_id: '{sheet_id}'
+      insert_index: '{insert_index}'
+      spreadsheet_id: '{spreadsheet_id}'
+      inherit_from_before: '{inherit_from_before}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_CREATE_SPREADSHEET_ROW

--- a/typescript/packages/composio/tools/composio_googlesheets_delete_dimension/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_delete_dimension/definition.yaml
@@ -1,0 +1,90 @@
+name: composio_googlesheets_delete_dimension
+description: >-
+  Tool to delete specified rows or columns from a sheet in a google spreadsheet. use when you need
+  to remove a range of rows or columns.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The ID of the spreadsheet.
+    required: true
+  response_ranges:
+    type: array
+    description: Limits the ranges of cells included in the response spreadsheet.
+    default: null
+  delete_dimension_request:
+    type: object
+    description: The details for the delete dimension request object.
+    required: true
+  response_include_grid_data:
+    type: boolean
+    description: >-
+      True if grid data should be returned. This parameter is ignored if a field mask was set in the
+      request.
+    default: null
+  include_spreadsheet_in_response:
+    type: boolean
+    description: Determines if the update response should include the spreadsheet resource.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_DELETE_DIMENSION
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_delete_dimension
+      spreadsheet_id: '{spreadsheet_id}'
+      response_ranges: '{response_ranges}'
+      delete_dimension_request: '{delete_dimension_request}'
+      response_include_grid_data: '{response_include_grid_data}'
+      include_spreadsheet_in_response: '{include_spreadsheet_in_response}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_DELETE_DIMENSION

--- a/typescript/packages/composio/tools/composio_googlesheets_delete_sheet/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_delete_sheet/definition.yaml
@@ -1,0 +1,75 @@
+name: composio_googlesheets_delete_sheet
+description: >-
+  Tool to delete a sheet (worksheet) from a spreadsheet. use when you need to remove a specific
+  sheet from a google sheet document.
+version: 1.0.0
+risk: high
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sheet_id:
+    type: number
+    description: >-
+      The ID of the sheet to delete. If the sheet is of DATA_SOURCE type, the associated DataSource
+      is also deleted.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet from which to delete the sheet.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_DELETE_SHEET
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_delete_sheet
+      sheet_id: '{sheet_id}'
+      spreadsheetId: '{spreadsheetId}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_DELETE_SHEET

--- a/typescript/packages/composio/tools/composio_googlesheets_execute_sql/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_execute_sql/definition.yaml
@@ -1,0 +1,87 @@
+name: composio_googlesheets_execute_sql
+description: >-
+  Execute sql queries against google sheets tables. supports select, insert, update, and delete
+  operations with familiar sql syntax. tables are automatically detected and mapped from the
+  spreadsheet structure.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sql:
+    type: string
+    description: SQL query to execute. Supports SELECT, INSERT, UPDATE, DELETE operations.
+    required: true
+  dry_run:
+    type: boolean
+    description: Preview changes without applying them (for write operations)
+    default: false
+  delete_method:
+    type: string
+    description: 'For DELETE operations: ''clear'' preserves row structure, ''remove_rows'' shifts data up'
+    enum:
+      - clear
+      - remove_rows
+    default: clear
+  spreadsheet_id:
+    type: string
+    description: Google Sheets ID
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_EXECUTE_SQL
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_execute_sql
+      sql: '{sql}'
+      dry_run: '{dry_run}'
+      delete_method: '{delete_method}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_EXECUTE_SQL

--- a/typescript/packages/composio/tools/composio_googlesheets_find_worksheet_by_title/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_find_worksheet_by_title/definition.yaml
@@ -1,0 +1,74 @@
+name: composio_googlesheets_find_worksheet_by_title
+description: >-
+  Finds a worksheet by its exact, case-sensitive title within a google spreadsheet; returns a
+  boolean indicating if found and the complete metadata of the entire spreadsheet, regardless of
+  whether the target worksheet is found.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  title:
+    type: string
+    description: The exact, case-sensitive title of the worksheet (tab name) to find.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The unique identifier of the Google Spreadsheet. This ID is part of the spreadsheet's URL.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_FIND_WORKSHEET_BY_TITLE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_find_worksheet_by_title
+      title: '{title}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_FIND_WORKSHEET_BY_TITLE

--- a/typescript/packages/composio/tools/composio_googlesheets_format_cell/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_format_cell/definition.yaml
@@ -1,0 +1,135 @@
+name: composio_googlesheets_format_cell
+description: Applies text and background cell formatting to a specified range in a google sheets worksheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  red:
+    type: number
+    description: Red component of the background color (0.0-1.0).
+    default: 0.9
+  blue:
+    type: number
+    description: Blue component of the background color (0.0-1.0).
+    default: 0.9
+  bold:
+    type: boolean
+    description: Apply bold formatting.
+    default: false
+  green:
+    type: number
+    description: Green component of the background color (0.0-1.0).
+    default: 0.9
+  italic:
+    type: boolean
+    description: Apply italic formatting.
+    default: false
+  fontSize:
+    type: number
+    description: Font size in points.
+    default: 10
+  underline:
+    type: boolean
+    description: Apply underline formatting.
+    default: false
+  worksheet_id:
+    type: number
+    description: ID (sheetId) of the worksheet. Use `GOOGLESHEETS_GET_SPREADSHEET_INFO` to find this ID.
+    required: true
+  end_row_index:
+    type: number
+    description: >-
+      0-based index of the row *after* the last row in the range (exclusive); must be greater than
+      `start_row_index`.
+    required: true
+  strikethrough:
+    type: boolean
+    description: Apply strikethrough formatting.
+    default: false
+  spreadsheet_id:
+    type: string
+    description: Identifier of the Google Sheets spreadsheet.
+    required: true
+  start_row_index:
+    type: number
+    description: 0-based index of the first row in the range.
+    required: true
+  end_column_index:
+    type: number
+    description: >-
+      0-based index of the column *after* the last column in the range (exclusive); must be greater
+      than `start_column_index`.
+    required: true
+  start_column_index:
+    type: number
+    description: 0-based index of the first column in the range.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_FORMAT_CELL
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_format_cell
+      red: '{red}'
+      blue: '{blue}'
+      bold: '{bold}'
+      green: '{green}'
+      italic: '{italic}'
+      fontSize: '{fontSize}'
+      underline: '{underline}'
+      worksheet_id: '{worksheet_id}'
+      end_row_index: '{end_row_index}'
+      strikethrough: '{strikethrough}'
+      spreadsheet_id: '{spreadsheet_id}'
+      start_row_index: '{start_row_index}'
+      end_column_index: '{end_column_index}'
+      start_column_index: '{start_column_index}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_FORMAT_CELL

--- a/typescript/packages/composio/tools/composio_googlesheets_get_sheet_names/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_get_sheet_names/definition.yaml
@@ -1,0 +1,70 @@
+name: composio_googlesheets_get_sheet_names
+description: >-
+  Lists all worksheet names from a specified google spreadsheet (which must exist), useful for
+  discovering sheets before further operations.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: >-
+      The unique identifier of the Google Spreadsheet. This ID is typically found in the
+      spreadsheet's URL.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_GET_SHEET_NAMES
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_get_sheet_names
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_GET_SHEET_NAMES

--- a/typescript/packages/composio/tools/composio_googlesheets_get_spreadsheet_by_data_filter/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_get_spreadsheet_by_data_filter/definition.yaml
@@ -1,0 +1,84 @@
+name: composio_googlesheets_get_spreadsheet_by_data_filter
+description: >-
+  Returns the spreadsheet at the given id, filtered by the specified data filters. use this tool
+  when you need to retrieve specific subsets of data from a google sheet based on criteria like a1
+  notation, developer metadata, or grid ranges.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  dataFilters:
+    type: array
+    description: The DataFilters used to select which ranges to retrieve.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet to request.
+    required: true
+  includeGridData:
+    type: boolean
+    description: True if grid data should be returned. Ignored if a field mask is set.
+    default: null
+  excludeTablesInBandedRanges:
+    type: boolean
+    description: True if tables should be excluded in the banded ranges. False if not set.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_GET_SPREADSHEET_BY_DATA_FILTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_get_spreadsheet_by_data_filter
+      dataFilters: '{dataFilters}'
+      spreadsheetId: '{spreadsheetId}'
+      includeGridData: '{includeGridData}'
+      excludeTablesInBandedRanges: '{excludeTablesInBandedRanges}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_GET_SPREADSHEET_BY_DATA_FILTER

--- a/typescript/packages/composio/tools/composio_googlesheets_get_spreadsheet_info/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_get_spreadsheet_info/definition.yaml
@@ -1,0 +1,66 @@
+name: composio_googlesheets_get_spreadsheet_info
+description: Retrieves comprehensive metadata for a google spreadsheet using its id, excluding cell data.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: Unique identifier of the Google Spreadsheet, typically found in its URL.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_GET_SPREADSHEET_INFO
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_get_spreadsheet_info
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_GET_SPREADSHEET_INFO

--- a/typescript/packages/composio/tools/composio_googlesheets_get_table_schema/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_get_table_schema/definition.yaml
@@ -1,0 +1,88 @@
+name: composio_googlesheets_get_table_schema
+description: >-
+  This action is used to get the schema of a table in a google spreadsheet, call this action to get
+  the schema of a table in a spreadsheet before you query the table. analyze table structure and
+  infer column names, types, and constraints. uses statistical analysis of sample data to determine
+  the most likely data type for each column. call this action after calling the list tables action
+  to get the schema of a table in a spreadsheet.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sheet_name:
+    type: string
+    description: Sheet/tab name if table_name is ambiguous across multiple sheets
+    default: null
+  table_name:
+    type: string
+    description: >-
+      Specific table name from LIST_TABLES response (e.g., 'Sales_Data', 'Employee_List'). Use
+      'auto' to analyze the largest/most prominent table.
+    required: true
+  sample_size:
+    type: number
+    description: Number of rows to sample for type inference
+    default: 50
+  spreadsheet_id:
+    type: string
+    description: Google Sheets ID
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_GET_TABLE_SCHEMA
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_get_table_schema
+      sheet_name: '{sheet_name}'
+      table_name: '{table_name}'
+      sample_size: '{sample_size}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_GET_TABLE_SCHEMA

--- a/typescript/packages/composio/tools/composio_googlesheets_insert_dimension/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_insert_dimension/definition.yaml
@@ -1,0 +1,90 @@
+name: composio_googlesheets_insert_dimension
+description: >-
+  Tool to insert new rows or columns into a sheet at a specified location. use when you need to add
+  empty rows or columns within an existing google sheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The ID of the spreadsheet to update.
+    required: true
+  response_ranges:
+    type: array
+    description: Limits the ranges of the spreadsheet to include in the response.
+    default: null
+  insert_dimension:
+    type: object
+    description: The details for the insert dimension request.
+    required: true
+  response_include_grid_data:
+    type: boolean
+    description: >-
+      True if grid data should be included in the response (if includeSpreadsheetInResponse is
+      true).
+    default: null
+  include_spreadsheet_in_response:
+    type: boolean
+    description: True if the updated spreadsheet should be included in the response.
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_INSERT_DIMENSION
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_insert_dimension
+      spreadsheet_id: '{spreadsheet_id}'
+      response_ranges: '{response_ranges}'
+      insert_dimension: '{insert_dimension}'
+      response_include_grid_data: '{response_include_grid_data}'
+      include_spreadsheet_in_response: '{include_spreadsheet_in_response}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_INSERT_DIMENSION

--- a/typescript/packages/composio/tools/composio_googlesheets_list_tables/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_list_tables/definition.yaml
@@ -1,0 +1,85 @@
+name: composio_googlesheets_list_tables
+description: >-
+  This action is used to list all tables in a google spreadsheet, call this action to get the list
+  of tables in a spreadsheet. discover all tables in a google spreadsheet by analyzing sheet
+  structure and detecting data patterns. uses heuristic analysis to find header rows, data
+  boundaries, and table structures.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  min_rows:
+    type: number
+    description: Minimum number of data rows to consider a valid table
+    default: 2
+  min_columns:
+    type: number
+    description: Minimum number of columns to consider a valid table
+    default: 1
+  min_confidence:
+    type: number
+    description: Minimum confidence score (0.0-1.0) to consider a valid table
+    default: 0.5
+  spreadsheet_id:
+    type: string
+    description: Google Sheets ID from the URL (e.g., '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms')
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_LIST_TABLES
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_list_tables
+      min_rows: '{min_rows}'
+      min_columns: '{min_columns}'
+      min_confidence: '{min_confidence}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_LIST_TABLES

--- a/typescript/packages/composio/tools/composio_googlesheets_lookup_spreadsheet_row/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_lookup_spreadsheet_row/definition.yaml
@@ -1,0 +1,86 @@
+name: composio_googlesheets_lookup_spreadsheet_row
+description: >-
+  Finds the first row in a google spreadsheet where a cell's entire content exactly matches the
+  query string, searching within a specified a1 notation range or the first sheet by default.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  query:
+    type: string
+    description: Exact text value to find; matches the entire content of a cell in a row.
+    required: true
+  range:
+    type: string
+    description: >-
+      A1 notation of the range to search (e.g., 'Sheet1!A1:D5', 'MySheet!A:Z', or 'Sheet1').
+      Defaults to the non-empty part of the first sheet. For multiple sheets, include sheet name
+      (e.g., 'SheetName!A1:Z100').
+    default: null
+  case_sensitive:
+    type: boolean
+    description: If `True`, the query string search is case-sensitive.
+    default: false
+  spreadsheet_id:
+    type: string
+    description: Identifier of the Google Spreadsheet to search.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_LOOKUP_SPREADSHEET_ROW
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_lookup_spreadsheet_row
+      query: '{query}'
+      range: '{range}'
+      case_sensitive: '{case_sensitive}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_LOOKUP_SPREADSHEET_ROW

--- a/typescript/packages/composio/tools/composio_googlesheets_query_table/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_query_table/definition.yaml
@@ -1,0 +1,82 @@
+name: composio_googlesheets_query_table
+description: >-
+  This action is used to query a table in a google spreadsheet, call this action to query a table in
+  a spreadsheet. execute sql-like select queries against spreadsheet tables. supports where
+  conditions, order by, limit clauses. call this action after calling the get table schema action to
+  query a table in a spreadsheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sql:
+    type: string
+    description: >-
+      SQL SELECT query. Supported: SELECT cols FROM table WHERE conditions ORDER BY col LIMIT n.
+      Table names must be quoted if they contain spaces.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: Google Sheets ID
+    required: true
+  include_formulas:
+    type: boolean
+    description: Whether to return formula text instead of calculated values for formula columns
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_QUERY_TABLE
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_query_table
+      sql: '{sql}'
+      spreadsheet_id: '{spreadsheet_id}'
+      include_formulas: '{include_formulas}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_QUERY_TABLE

--- a/typescript/packages/composio/tools/composio_googlesheets_search_developer_metadata/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_search_developer_metadata/definition.yaml
@@ -1,0 +1,75 @@
+name: composio_googlesheets_search_developer_metadata
+description: >-
+  Tool to search for developer metadata in a spreadsheet. use when you need to find specific
+  metadata entries based on filters.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  dataFilters:
+    type: array
+    description: >-
+      The data filters describing the criteria used to determine which DeveloperMetadata entries to
+      return.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet to retrieve metadata from.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SEARCH_DEVELOPER_METADATA
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_search_developer_metadata
+      dataFilters: '{dataFilters}'
+      spreadsheetId: '{spreadsheetId}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SEARCH_DEVELOPER_METADATA

--- a/typescript/packages/composio/tools/composio_googlesheets_search_spreadsheets/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_search_spreadsheets/definition.yaml
@@ -1,0 +1,108 @@
+name: composio_googlesheets_search_spreadsheets
+description: >-
+  Search for google spreadsheets using various filters including name, content, date ranges, and
+  more.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  query:
+    type: string
+    description: >-
+      Search query to filter spreadsheets. Can search by name (name contains 'budget'), full text
+      content (fullText contains 'sales'), or use complex queries with operators like 'and', 'or',
+      'not'. Leave empty to get all spreadsheets.
+    default: null
+  order_by:
+    type: string
+    description: >-
+      Order results by field. Common options: 'modifiedTime desc', 'modifiedTime asc', 'name',
+      'createdTime desc'
+    default: modifiedTime desc
+  max_results:
+    type: number
+    description: Maximum number of spreadsheets to return (1-1000). Defaults to 10.
+    default: 10
+  starred_only:
+    type: boolean
+    description: Whether to return only starred spreadsheets. Defaults to False.
+    default: false
+  created_after:
+    type: string
+    description: Return spreadsheets created after this date. Use RFC 3339 format like '2024-01-01T00:00:00Z'.
+    default: null
+  modified_after:
+    type: string
+    description: Return spreadsheets modified after this date. Use RFC 3339 format like '2024-01-01T00:00:00Z'.
+    default: null
+  shared_with_me:
+    type: boolean
+    description: Whether to return only spreadsheets shared with the current user. Defaults to False.
+    default: false
+  include_trashed:
+    type: boolean
+    description: Whether to include spreadsheets in trash. Defaults to False.
+    default: false
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SEARCH_SPREADSHEETS
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_search_spreadsheets
+      query: '{query}'
+      order_by: '{order_by}'
+      max_results: '{max_results}'
+      starred_only: '{starred_only}'
+      created_after: '{created_after}'
+      modified_after: '{modified_after}'
+      shared_with_me: '{shared_with_me}'
+      include_trashed: '{include_trashed}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SEARCH_SPREADSHEETS

--- a/typescript/packages/composio/tools/composio_googlesheets_set_basic_filter/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_set_basic_filter/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googlesheets_set_basic_filter
+description: >-
+  Tool to set a basic filter on a sheet in a google spreadsheet. use when you need to filter or sort
+  data within a specific range on a sheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  filter:
+    type: object
+    description: The filter to set.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SET_BASIC_FILTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_set_basic_filter
+      filter: '{filter}'
+      spreadsheetId: '{spreadsheetId}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SET_BASIC_FILTER

--- a/typescript/packages/composio/tools/composio_googlesheets_sheet_from_json/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_sheet_from_json/definition.yaml
@@ -1,0 +1,83 @@
+name: composio_googlesheets_sheet_from_json
+description: >-
+  Creates a new google spreadsheet and populates its first worksheet from `sheet json`, which must
+  be non-empty as its first item's keys establish the headers.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  title:
+    type: string
+    description: The desired title for the new Google Spreadsheet.
+    required: true
+  sheet_json:
+    type: array
+    description: >-
+      A list of dictionaries representing the rows of the sheet. Each dictionary must have the same
+      set of keys, which will form the header row. Values can be strings, numbers, booleans, or null
+      (represented as empty cells).
+    required: true
+  sheet_name:
+    type: string
+    description: >-
+      The name for the first worksheet within the newly created spreadsheet. This name will appear
+      as a tab at the bottom of the sheet.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SHEET_FROM_JSON
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_sheet_from_json
+      title: '{title}'
+      sheet_json: '{sheet_json}'
+      sheet_name: '{sheet_name}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SHEET_FROM_JSON

--- a/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_sheets_copy_to/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_sheets_copy_to/definition.yaml
@@ -1,0 +1,78 @@
+name: composio_googlesheets_spreadsheets_sheets_copy_to
+description: >-
+  Tool to copy a single sheet from a spreadsheet to another spreadsheet. use when you need to
+  duplicate a sheet into a different spreadsheet.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  sheet_id:
+    type: number
+    description: The ID of the sheet to copy.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The ID of the spreadsheet containing the sheet to copy.
+    required: true
+  destination_spreadsheet_id:
+    type: string
+    description: The ID of the spreadsheet to copy the sheet to.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SPREADSHEETS_SHEETS_COPY_TO
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_spreadsheets_sheets_copy_to
+      sheet_id: '{sheet_id}'
+      spreadsheet_id: '{spreadsheet_id}'
+      destination_spreadsheet_id: '{destination_spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SPREADSHEETS_SHEETS_COPY_TO

--- a/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_append/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_append/definition.yaml
@@ -1,0 +1,140 @@
+name: composio_googlesheets_spreadsheets_values_append
+description: >-
+  Tool to append values to a spreadsheet. use when you need to add new data to the end of an
+  existing table in a google sheet.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  range:
+    type: string
+    description: >-
+      The A1 notation of a range to search for a logical table of data. Values are appended after
+      the last row of the table.
+    required: true
+  values:
+    type: array
+    description: >-
+      The data to be written. This is an array of arrays, the outer array representing all the data
+      and each inner array representing a major dimension. Each item in the inner array corresponds
+      with one cell.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet to update.
+    required: true
+  majorDimension:
+    type: string
+    description: >-
+      The major dimension of the values. For output, if the spreadsheet data is:
+      A1=1,B1=2,A2=3,B2=4, then requesting range=A1:B2,majorDimension=ROWS will return
+      [[1,2],[3,4]], whereas requesting range=A1:B2,majorDimension=COLUMNS will return
+      [[1,3],[2,4]].
+    enum:
+      - ROWS
+      - COLUMNS
+    default: null
+  insertDataOption:
+    type: string
+    description: How the input data should be inserted.
+    enum:
+      - OVERWRITE
+      - INSERT_ROWS
+    default: null
+  valueInputOption:
+    type: string
+    description: How the input data should be interpreted.
+    required: true
+    enum:
+      - RAW
+      - USER_ENTERED
+  includeValuesInResponse:
+    type: boolean
+    description: >-
+      Determines if the update response should include the values of the cells that were appended.
+      By default, responses do not include the updated values.
+    default: null
+  responseValueRenderOption:
+    type: string
+    description: >-
+      Determines how values in the response should be rendered. The default render option is
+      FORMATTED_VALUE.
+    enum:
+      - FORMATTED_VALUE
+      - UNFORMATTED_VALUE
+      - FORMULA
+    default: null
+  responseDateTimeRenderOption:
+    type: string
+    description: >-
+      Determines how dates, times, and durations in the response should be rendered. This is ignored
+      if responseValueRenderOption is FORMATTED_VALUE. The default dateTime render option is
+      SERIAL_NUMBER.
+    enum:
+      - SERIAL_NUMBER
+      - FORMATTED_STRING
+    default: null
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SPREADSHEETS_VALUES_APPEND
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_spreadsheets_values_append
+      range: '{range}'
+      values: '{values}'
+      spreadsheetId: '{spreadsheetId}'
+      majorDimension: '{majorDimension}'
+      insertDataOption: '{insertDataOption}'
+      valueInputOption: '{valueInputOption}'
+      includeValuesInResponse: '{includeValuesInResponse}'
+      responseValueRenderOption: '{responseValueRenderOption}'
+      responseDateTimeRenderOption: '{responseDateTimeRenderOption}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SPREADSHEETS_VALUES_APPEND

--- a/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_batch_clear/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_batch_clear/definition.yaml
@@ -1,0 +1,73 @@
+name: composio_googlesheets_spreadsheets_values_batch_clear
+description: >-
+  Tool to clear one or more ranges of values from a spreadsheet. use when you need to remove data
+  from specific cells or ranges while keeping formatting and other properties intact.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  ranges:
+    type: array
+    description: The ranges to clear, in A1 notation or R1C1 notation.
+    required: true
+  spreadsheet_id:
+    type: string
+    description: The ID of the spreadsheet to update.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SPREADSHEETS_VALUES_BATCH_CLEAR
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_spreadsheets_values_batch_clear
+      ranges: '{ranges}'
+      spreadsheet_id: '{spreadsheet_id}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SPREADSHEETS_VALUES_BATCH_CLEAR

--- a/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_batch_clear_by_data_filter/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_batch_clear_by_data_filter/definition.yaml
@@ -1,0 +1,76 @@
+name: composio_googlesheets_spreadsheets_values_batch_clear_by_data_filter
+description: >-
+  Clears one or more ranges of values from a spreadsheet using data filters. the caller must specify
+  the spreadsheet id and one or more datafilters. ranges matching any of the specified data filters
+  will be cleared. only values are cleared -- all other properties of the cell (such as formatting,
+  data validation, etc..) are kept.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  dataFilters:
+    type: array
+    description: The DataFilters used to determine which ranges to clear.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet to update.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: >-
+    https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SPREADSHEETS_VALUES_BATCH_CLEAR_BY_DATA_FILTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_spreadsheets_values_batch_clear_by_data_filter
+      dataFilters: '{dataFilters}'
+      spreadsheetId: '{spreadsheetId}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SPREADSHEETS_VALUES_BATCH_CLEAR_BY_DATA_FILTER

--- a/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_batch_get_by_data_filter/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_spreadsheets_values_batch_get_by_data_filter/definition.yaml
@@ -1,0 +1,108 @@
+name: composio_googlesheets_spreadsheets_values_batch_get_by_data_filter
+description: >-
+  Tool to return one or more ranges of values from a spreadsheet that match the specified data
+  filters. use when you need to retrieve specific data sets based on filtering criteria rather than
+  entire sheets or fixed ranges.
+version: 1.0.0
+risk: low
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  dataFilters:
+    type: array
+    description: >-
+      The data filters used to match the ranges of values to retrieve. Ranges that match any of the
+      specified data filters are included in the response.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet to retrieve data from.
+    required: true
+  majorDimension:
+    type: string
+    description: >-
+      The major dimension that results should use. For example, if the spreadsheet data is:
+      A1=1,B1=2,A2=3,B2=4, then a request that selects that range and sets majorDimension=ROWS
+      returns [[1,2],[3,4]], whereas a request that sets majorDimension=COLUMNS returns
+      [[1,3],[2,4]].
+    enum:
+      - ROWS
+      - COLUMNS
+    default: null
+  valueRenderOption:
+    type: string
+    description: How values should be represented in the output. The default render option is FORMATTED_VALUE.
+    enum:
+      - FORMATTED_VALUE
+      - UNFORMATTED_VALUE
+      - FORMULA
+    default: null
+  dateTimeRenderOption:
+    type: string
+    description: >-
+      How dates, times, and durations should be represented in the output. This is ignored if
+      valueRenderOption is FORMATTED_VALUE. The default dateTime render option is SERIAL_NUMBER.
+    enum:
+      - SERIAL_NUMBER
+      - FORMATTED_STRING
+    default: null
+execution:
+  type: http
+  method: POST
+  url: >-
+    https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_SPREADSHEETS_VALUES_BATCH_GET_BY_DATA_FILTER
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_spreadsheets_values_batch_get_by_data_filter
+      dataFilters: '{dataFilters}'
+      spreadsheetId: '{spreadsheetId}'
+      majorDimension: '{majorDimension}'
+      valueRenderOption: '{valueRenderOption}'
+      dateTimeRenderOption: '{dateTimeRenderOption}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_SPREADSHEETS_VALUES_BATCH_GET_BY_DATA_FILTER

--- a/typescript/packages/composio/tools/composio_googlesheets_update_sheet_properties/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_update_sheet_properties/definition.yaml
@@ -1,0 +1,74 @@
+name: composio_googlesheets_update_sheet_properties
+description: >-
+  Tool to update properties of a sheet (worksheet) within a google spreadsheet, such as its title,
+  index, visibility, tab color, or grid properties. use this when you need to modify the metadata or
+  appearance of a specific sheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet containing the sheet to update.
+    required: true
+  updateSheetProperties:
+    type: object
+    description: The details of the sheet properties to update.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_UPDATE_SHEET_PROPERTIES
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_update_sheet_properties
+      spreadsheetId: '{spreadsheetId}'
+      updateSheetProperties: '{updateSheetProperties}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_UPDATE_SHEET_PROPERTIES

--- a/typescript/packages/composio/tools/composio_googlesheets_update_spreadsheet_properties/definition.yaml
+++ b/typescript/packages/composio/tools/composio_googlesheets_update_spreadsheet_properties/definition.yaml
@@ -1,0 +1,81 @@
+name: composio_googlesheets_update_spreadsheet_properties
+description: >-
+  Tool to update properties of a spreadsheet, such as its title, locale, or auto-recalculation
+  settings. use when you need to modify the overall configuration of a google sheet.
+version: 1.0.0
+risk: medium
+parameters:
+  composio_user_id:
+    type: string
+    description: The Composio entity/user ID for the calling tenant or user.
+    required: true
+  composio_connected_account_id:
+    type: string
+    description: >-
+      The Composio connected account ID for the GOOGLESHEETS toolkit, scoped to the calling tenant.
+      The "Connect GOOGLESHEETS" flow must be completed before this tool will succeed.
+    required: true
+  fields:
+    type: string
+    description: >-
+      The fields that should be updated. Use '*' for all fields in 'properties' or a comma-separated
+      list (e.g., 'title,locale,iterativeCalculationSettings.maxIterations'). The root 'properties'
+      is implied.
+    required: true
+  properties:
+    type: object
+    description: The properties to update. At least one field within properties must be set.
+    required: true
+  spreadsheetId:
+    type: string
+    description: The ID of the spreadsheet to update.
+    required: true
+execution:
+  type: http
+  method: POST
+  url: https://backend.composio.dev/api/v3/tools/execute/GOOGLESHEETS_UPDATE_SPREADSHEET_PROPERTIES
+  headers:
+    x-api-key: '{COMPOSIO_API_KEY}'
+    Content-Type: application/json
+  body:
+    user_id: '{composio_user_id}'
+    connected_account_id: '{composio_connected_account_id}'
+    arguments:
+      _matimo_tool: composio_googlesheets_update_spreadsheet_properties
+      fields: '{fields}'
+      properties: '{properties}'
+      spreadsheetId: '{spreadsheetId}'
+  timeout: 30000
+authentication:
+  type: api_key
+  location: header
+  name: x-api-key
+output_schema:
+  type: object
+  description: Response envelope from Composio's tool execution endpoint.
+  properties:
+    success:
+      type: boolean
+      description: Whether the HTTP request to Composio succeeded (2xx status).
+    data:
+      type: object
+      description: Composio's response body.
+      properties:
+        data:
+          type: object
+          description: The action-specific result payload.
+        error:
+          type:
+            - string
+            - 'null'
+          description: Error message if Composio could not execute the action.
+        successful:
+          type: boolean
+          description: Whether Composio successfully executed the underlying action.
+tags:
+  - composio
+  - googlesheets
+notes:
+  env: COMPOSIO_API_KEY
+  toolkit: googlesheets
+  composio_slug: GOOGLESHEETS_UPDATE_SPREADSHEET_PROPERTIES

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Core SDK for Matimo: Framework-agnostic YAML-driven tool ecosystem for AI agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/typescript/packages/core/test/integration/matimo-instance-hitl-paths.test.ts
+++ b/typescript/packages/core/test/integration/matimo-instance-hitl-paths.test.ts
@@ -10,6 +10,12 @@ import { MatimoInstance } from '../../src/matimo-instance';
  * 1201-1239 (#resolveHITL approval manifest & callback paths)
  */
 describe('MatimoInstance — HITL & Reload Paths', () => {
+  // Every test here drives matimo.execute() through policy + HITL evaluation
+  // and a real `type: command` (echo) child-process spawn — under CPU
+  // contention (parallel CI workers, throttled runners) that chain can
+  // exceed Jest's 5000ms default even though the logic itself is correct.
+  jest.setTimeout(15000);
+
   let tmpDir: string;
   let toolDir: string;
   let approvalDir: string;

--- a/typescript/packages/github/package.json
+++ b/typescript/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/github",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "GitHub API tools for Matimo - Full-featured GitHub integration with OAuth2 and PAT support",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/github/package.json
+++ b/typescript/packages/github/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/github",
   "version": "0.1.6",
   "description": "GitHub API tools for Matimo - Full-featured GitHub integration with OAuth2 and PAT support",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/gmail/package.json
+++ b/typescript/packages/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/gmail",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Gmail tools for Matimo",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/gmail/package.json
+++ b/typescript/packages/gmail/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/gmail",
   "version": "0.1.6",
   "description": "Gmail tools for Matimo",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/hubspot/package.json
+++ b/typescript/packages/hubspot/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/hubspot",
   "version": "0.1.6",
   "description": "HubSpot tools for Matimo - universal CRM, marketing, and automation integration.",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/hubspot/package.json
+++ b/typescript/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/hubspot",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "HubSpot tools for Matimo - universal CRM, marketing, and automation integration.",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/mailchimp/package.json
+++ b/typescript/packages/mailchimp/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/mailchimp",
   "version": "0.1.6",
   "description": "Mailchimp email marketing tools for Matimo \u2014 manage audiences, subscribers, and campaigns",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/mailchimp/package.json
+++ b/typescript/packages/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/mailchimp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Mailchimp email marketing tools for Matimo \u2014 manage audiences, subscribers, and campaigns",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/microsoft/package.json
+++ b/typescript/packages/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/microsoft",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Microsoft Graph tools for Matimo (search, files, mail, Teams, calendar, SharePoint)",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/microsoft/package.json
+++ b/typescript/packages/microsoft/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/microsoft",
   "version": "0.1.6",
   "description": "Microsoft Graph tools for Matimo (search, files, mail, Teams, calendar, SharePoint)",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/notion/package.json
+++ b/typescript/packages/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/notion",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Notion workspace tools for Matimo",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/notion/package.json
+++ b/typescript/packages/notion/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/notion",
   "version": "0.1.6",
   "description": "Notion workspace tools for Matimo",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/postgres/package.json
+++ b/typescript/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/postgres",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Postgres tools for Matimo",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/postgres/package.json
+++ b/typescript/packages/postgres/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/postgres",
   "version": "0.1.6",
   "description": "Postgres tools for Matimo",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/slack/package.json
+++ b/typescript/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/slack",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Slack workspace tools for Matimo",
   "license": "MIT",
   "type": "module",

--- a/typescript/packages/slack/package.json
+++ b/typescript/packages/slack/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/slack",
   "version": "0.1.6",
   "description": "Slack workspace tools for Matimo",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/twilio/package.json
+++ b/typescript/packages/twilio/package.json
@@ -2,6 +2,7 @@
   "name": "@matimo/twilio",
   "version": "0.1.6",
   "description": "Twilio messaging tools for Matimo \u2014 send SMS, MMS, and manage messages",
+  "license": "MIT",
   "type": "module",
   "files": [
     "tools",

--- a/typescript/packages/twilio/package.json
+++ b/typescript/packages/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matimo/twilio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Twilio messaging tools for Matimo \u2014 send SMS, MMS, and manage messages",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description
release: v0.1.7 — Composio Google Workspace expansion + BYOK compliance docs
Base: main → Head: release/v0.1.7 (11 commits, 137 files, +9597/−36)

Summary
New: @matimo/composio's catalog gains 5 Google Workspace toolkits — Gmail (23), Google Sheets (36), Google Docs (32), Google Forms (7), Google Meet (9) — 107 new tools, taking the package from 342 → 449 tools across 9 → 14 toolkits
New: Gmail toolkit exercised across all four example patterns (factory, decorator, LangChain, HITL-approval)
Docs: BYOK (bring-your-own-key) credential model documented explicitly for @matimo/composio — non-affiliation disclaimer, links to Composio's Terms of Service and Privacy Policy, added to the package README and docs/COMPOSIO.md
Docs: New THIRD_PARTY_NOTICES.md — every third-party provider Matimo can connect to, its credential env var, and a link to that provider's own terms
Docs: CONTRIBUTING.md and SECURITY.md now mandate the BYOK pattern for all future third-party connectors, not just Composio
Docs: docs/RELEASES.md and CHANGELOG.md backfilled with a v0.1.7 entry; docs/COMPOSIO.md toolkit table/counts updated
Fix: missing license: MIT field added to provider sub-package manifests (silenced an npm/pnpm publish warning)
Fix (CI): pinned uv run ruff (locked 0.15.9) instead of the floating uv tool run ruff, which pulled an unpinned version and flagged findings never enforced for these packages
Test: HITL integration tests given headroom above Jest's 5000ms default (real type: command child-process spawn + approval-manifest disk I/O had no prior margin)
Version: all 13 typescript/ packages bumped 0.1.6 → 0.1.7 in lockstep
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Tool addition
- [x] Tool modification

## Testing
- [ ] Tests added
- [x] All tests passing
- [x] Coverage maintained (>90%)

## Checklist
- [x] Code formatted (`pnpm format`)
- [x] Linting passes (`pnpm lint`)
- [x] Tests passing (`pnpm test`)
- [x] Documentation updated
- [x] No console.log statements
- [x] No hardcoded secrets
- [x] Tool YAML validated (if applicable)

## Related Issues
Closes #[issue number]
